### PR TITLE
Localize UV Admin strings and sanitize URLs

### DIFF
--- a/plugins/uv-admin/readme.md
+++ b/plugins/uv-admin/readme.md
@@ -1,1 +1,5 @@
 UV Admin provides a branded control panel and cleaner editor UI.
+
+## Translation
+
+All user-facing strings are translation ready. The plugin loads the `uv-admin` text domain from its `languages` directory so translations can be provided via standard WordPress `.po`/`.mo` files or translation plugins.

--- a/plugins/uv-admin/uv-admin.php
+++ b/plugins/uv-admin/uv-admin.php
@@ -20,35 +20,35 @@ function uv_admin_get_docs_url(){
 
 // Settings page
 add_action('admin_menu', function(){
-    add_options_page('Unge Vil Admin', 'Unge Vil Admin', 'manage_options', 'uv-admin', 'uv_admin_settings_page');
+    add_options_page(__('Unge Vil Admin','uv-admin'), __('Unge Vil Admin','uv-admin'), 'manage_options', 'uv-admin', 'uv_admin_settings_page');
 });
 
 function uv_admin_settings_page(){
     if(isset($_POST['uv_admin_docs_url']) && check_admin_referer('uv_admin_save','uv_admin_nonce')){
         update_option('uv_admin_docs_url', esc_url_raw($_POST['uv_admin_docs_url']));
-        echo '<div class="updated"><p>Saved.</p></div>';
+        echo '<div class="updated"><p>' . esc_html( __('Saved.', 'uv-admin') ) . '</p></div>';
     }
     $docs = uv_admin_get_docs_url();
-    echo '<div class="wrap"><h1>Unge Vil Admin</h1>';
+    echo '<div class="wrap"><h1>' . esc_html( __('Unge Vil Admin', 'uv-admin') ) . '</h1>';
     echo '<form method="post">';
     wp_nonce_field('uv_admin_save','uv_admin_nonce');
     echo '<table class="form-table">
-            <tr><th scope="row"><label for="uv_admin_docs_url">Docs URL</label></th>
-                <td><input type="url" name="uv_admin_docs_url" id="uv_admin_docs_url" value="'.esc_attr($docs).'" class="regular-text" placeholder="https://sites.google.com/..."></td></tr>
+            <tr><th scope="row"><label for="uv_admin_docs_url">' . esc_html( __('Docs URL', 'uv-admin') ) . '</label></th>
+                <td><input type="url" name="uv_admin_docs_url" id="uv_admin_docs_url" value="' . esc_attr($docs) . '" class="regular-text" placeholder="' . esc_attr( __('https://sites.google.com/...', 'uv-admin') ) . '"></td></tr>
           </table>';
-    submit_button('Save');
+    submit_button(__('Save','uv-admin'));
     echo '</form></div>';
 }
 
 // Custom admin color scheme
 add_action('admin_init', function(){
-    $css = plugins_url('assets/admin-colors.css', __FILE__);
+    $css = esc_url( plugins_url('assets/admin-colors.css', __FILE__) );
     wp_admin_css_color('uv', __('Unge Vil','uv-admin'), $css, ['#1f1b24','#9900ff','#ffffff','#f5f5f7']);
 });
 
 // Enqueue small admin CSS (cards, control panel visuals)
 add_action('admin_enqueue_scripts', function($hook){
-    wp_enqueue_style('uv-admin', plugins_url('assets/admin.css', __FILE__), [], '1.0');
+    wp_enqueue_style('uv-admin', esc_url( plugins_url('assets/admin.css', __FILE__) ), [], '1.0');
 });
 
 // Login branding
@@ -87,32 +87,32 @@ add_action('admin_menu', function(){
 
 // Control Panel (top-level menu)
 add_action('admin_menu', function(){
-    add_menu_page('Control Panel','Control Panel','edit_posts','uv-control-panel','uv_admin_control_panel','dashicons-layout',2);
+    add_menu_page(__('Control Panel','uv-admin'), __('Control Panel','uv-admin'),'edit_posts','uv-control-panel','uv_admin_control_panel','dashicons-layout',2);
 });
 
 function uv_admin_control_panel(){
     $docs = uv_admin_get_docs_url();
     $cards = [
-        ['News','edit.php','dashicons-megaphone'],
-        ['Media','upload.php','dashicons-format-image'],
-        ['Pages','edit.php?post_type=page','dashicons-admin-page'],
-        ['Locations','edit-tags.php?taxonomy=uv_location','dashicons-location'],
-        ['Activities','edit.php?post_type=uv_activity','dashicons-forms'],
-        ['Partners','edit.php?post_type=uv_partner','dashicons-heart'],
-        ['Team Assignments','edit.php?post_type=uv_team_assignment','dashicons-groups'],
+        [__('News','uv-admin'),'edit.php','dashicons-megaphone'],
+        [__('Media','uv-admin'),'upload.php','dashicons-format-image'],
+        [__('Pages','uv-admin'),'edit.php?post_type=page','dashicons-admin-page'],
+        [__('Locations','uv-admin'),'edit-tags.php?taxonomy=uv_location','dashicons-location'],
+        [__('Activities','uv-admin'),'edit.php?post_type=uv_activity','dashicons-forms'],
+        [__('Partners','uv-admin'),'edit.php?post_type=uv_partner','dashicons-heart'],
+        [__('Team Assignments','uv-admin'),'edit.php?post_type=uv_team_assignment','dashicons-groups'],
     ];
-    if(post_type_exists('tribe_events')) $cards[] = ['Events','edit.php?post_type=tribe_events','dashicons-calendar-alt'];
+    if(post_type_exists('tribe_events')) $cards[] = [__('Events','uv-admin'),'edit.php?post_type=tribe_events','dashicons-calendar-alt'];
     echo '<div class="wrap uv-control-panel">';
-    echo '<div class="uvcp-header"><img alt="Unge Vil" src="'.esc_url(get_stylesheet_directory_uri().'/assets/img/logo.svg').'"><h1>Unge Vil — Control Panel</h1></div>';
+    echo '<div class="uvcp-header"><img alt="Unge Vil" src="' . esc_url(get_stylesheet_directory_uri().'/assets/img/logo.svg') . '"><h1>Unge Vil — ' . esc_html( __('Control Panel','uv-admin') ) . '</h1></div>';
     echo '<div class="uvcp-grid">';
     foreach($cards as $c){
-        echo '<a class="uvcp-card" href="'.admin_url($c[1]).'"><span class="dashicons '.$c[2].'"></span><strong>'.$c[0].'</strong></a>';
+        echo '<a class="uvcp-card" href="' . esc_url( admin_url($c[1]) ) . '"><span class="dashicons ' . esc_attr($c[2]) . '"></span><strong>' . esc_html($c[0]) . '</strong></a>';
     }
     echo '</div>';
     if($docs){
-        echo '<p class="uvcp-docs"><a class="button button-primary" href="'.esc_url($docs).'" target="_blank" rel="noopener">Open Team Docs</a></p>';
+        echo '<p class="uvcp-docs"><a class="button button-primary" href="' . esc_url($docs) . '" target="_blank" rel="noopener">' . esc_html( __('Open Team Docs','uv-admin') ) . '</a></p>';
     } else {
-        echo '<p class="uvcp-docs">Tip: set your Docs URL in <a href="'.admin_url('options-general.php?page=uv-admin').'">Settings → Unge Vil Admin</a>.</p>';
+        echo '<p class="uvcp-docs">' . sprintf( __('Tip: set your Docs URL in %sSettings → Unge Vil Admin%s.', 'uv-admin' ), '<a href="' . esc_url( admin_url('options-general.php?page=uv-admin') ) . '">', '</a>' ) . '</p>';
     }
     echo '</div>';
 }
@@ -122,8 +122,8 @@ add_action('admin_bar_menu', function($bar){
     if(!is_admin() || !current_user_can('edit_posts')) return;
     $bar->add_node([
         'id'=>'uvcp',
-        'title'=>'Control Panel',
-        'href'=>admin_url('admin.php?page=uv-control-panel'),
+        'title'=>__('Control Panel','uv-admin'),
+        'href'=>esc_url( admin_url('admin.php?page=uv-control-panel') ),
         'meta'=>['class'=>'uvcp-bar']
     ]);
 }, 80);


### PR DESCRIPTION
## Summary
- Localize admin settings and control panel strings for `uv-admin`
- Escape dynamic admin and plugin URLs with `esc_url`
- Document translation support in plugin readme

## Testing
- `php -l plugins/uv-admin/uv-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6d06107c08328a664b670e4a84323