### PR TITLE
Add updating guide and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ While deploying or migrating, enable **Maintenance** plugin (already installed),
 ## Building ZIPs from GitHub
 Tag a release like `v0.1.0` and GitHub Actions will attach zips for the child theme and each plugin.
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
+See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
 ---
 © 2025 Unge Vil. MIT License.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,0 +1,26 @@
+# Updating from GitHub releases
+
+## 1. Get the new ZIPs
+1. Visit the repository's [Releases](https://github.com/ungevil/Unge-Vil-Website/releases) page.
+2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`).
+
+## 2. Back up the site
+1. In your hosting panel or backup plugin (e.g. UpdraftPlus), run a full backup.
+2. Ensure both the database and the `wp-content` directory are included.
+3. Store the backup somewhere safe before continuing.
+
+## 3. Upload updates via WP Admin
+### Child theme
+1. In **Appearance → Themes → Add New → Upload Theme**, choose the `uv-kadence-child` ZIP.
+2. Click **Install Now**, then **Replace current version** if prompted.
+3. Make sure the child theme is active after the upload.
+
+### Plugins
+1. Go to **Plugins → Add New → Upload Plugin**.
+2. Upload each plugin ZIP (`uv-core`, `uv-people`, `uv-events-bridge`) one at a time.
+3. Click **Install Now**, choose **Replace current version** when asked, then **Activate**.
+
+## 4. Verify versions
+1. In **Plugins**, confirm each plugin lists the new version number.
+2. In **Appearance → Themes**, open the child theme details and verify its version.
+3. Browse a few pages on the front‑end to confirm the site loads as expected.


### PR DESCRIPTION
## Summary
- add `docs/UPDATING.md` with instructions for downloading release zips, backing up, uploading updates via WP Admin, and verifying versions
- link update guide from README under "Building ZIPs from GitHub"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d4194420832882464f8eca3380c7