### PR TITLE
docs: add release tagging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,15 @@ Tag a release like `v0.1.0` and GitHub Actions will attach zips for the child th
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
 See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
+### Tagging and making releases
+1. Commit your changes and push them to GitHub.
+2. In the repository, click **Releases** → **Draft a new release**.
+3. In **Tag version**, enter a new tag like `v0.1.1` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
+4. Choose **Create new tag on publish**, leaving the target branch as `main`.
+5. Add a title and notes, then click **Publish release**. GitHub Actions will build ZIPs for the theme and each plugin and attach them to the release.
+6. After the workflow completes, download the ZIPs from the release page and upload them to WordPress to update.
+
+> To tag from the command line instead, run `git tag v0.1.1 && git push origin v0.1.1` before drafting the release.
+
 ---
 © 2025 Unge Vil. MIT License.


### PR DESCRIPTION
## Summary
- explain how to create a tagged release in GitHub
- note optional CLI tag command

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d56229948328a1974d60d21dafd7