### PR TITLE
feat: add focus-visible outlines

### DIFF
--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -6,6 +6,7 @@
 .uv-card{border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);overflow:hidden;background:#fff}
 .uv-card a{display:block;text-decoration:none}
 .uv-card .uv-card-body{padding:12px}
+.uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:2px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{outline:3px solid var(--uv-purple)}
 .uv-team-grid{display:grid;gap:1rem}
 @media(min-width:768px){.uv-team-grid{grid-template-columns:repeat(3,1fr)}}


### PR DESCRIPTION
## Summary
- highlight links and card components on keyboard focus with high-contrast outline and smooth transition

## Testing
- `npm test` *(fails: package.json not found)*
- `npx browserslist "defaults"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d6f65e8883288b75f464327b0dd0