### PR TITLE
Document plugin installation and shortcodes

### DIFF
--- a/plugins/uv-admin/readme.md
+++ b/plugins/uv-admin/readme.md
@@ -1,5 +1,17 @@
 UV Admin provides a branded control panel and cleaner editor UI.
 
-## Translation
+## Installation
+1. Upload `uv-admin` to `wp-content/plugins/`.
+2. Activate from the WordPress admin.
 
+## Shortcodes & Hooks
+This plugin does not expose public shortcodes or custom hooks.
+
+## Requirements
+- WordPress 6.0+
+
+## Example Usage
+Once activated the WordPress dashboard and editor are automatically styled; no shortcodes are required.
+
+## Translation
 All user-facing strings are translation ready. The plugin loads the `uv-admin` text domain from its `languages` directory so translations can be provided via standard WordPress `.po`/`.mo` files or translation plugins.

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -1,1 +1,24 @@
 UV Core registers CPTs, taxonomies, and shortcodes.
+
+## Installation
+1. Upload `uv-core` to `wp-content/plugins/`.
+2. Activate the plugin from the WordPress admin panel.
+
+## Shortcodes
+- `[uv_locations_grid columns="3" show_links="1"]` – display all Locations in a card grid.
+- `[uv_news location="osl" count="3"]` – list recent posts, optionally filtered by a Location slug.
+- `[uv_activities location="osl" columns="3"]` – grid of Activities for a Location.
+- `[uv_partners location="osl" type="sponsor" columns="4"]` – show Partners with optional Location or Partner Type filtering.
+
+## Requirements
+- WordPress 6.0+
+- Optional: Polylang for translating taxonomy terms.
+
+## Example Usage
+
+```html
+[uv_locations_grid columns="4" show_links="0"]
+```
+
+## Translation
+All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -1,1 +1,21 @@
 UV Events Bridge connects Locations to The Events Calendar.
+
+## Installation
+1. Upload `uv-events-bridge` to `wp-content/plugins/`.
+2. Activate the plugin in WordPress.
+
+## Shortcodes
+- `[uv_upcoming_events location="osl" count="5"]` – list upcoming Events optionally filtered by a Location term.
+
+## Requirements
+- WordPress 6.0+
+- The Events Calendar plugin must be active.
+
+## Example Usage
+
+```html
+[uv_upcoming_events location="bergen" count="3"]
+```
+
+## Translation
+All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -1,1 +1,21 @@
 UV People adds user profile fields, per-location assignments, and a team grid shortcode.
+
+## Installation
+1. Upload `uv-people` to `wp-content/plugins/`.
+2. Activate via the WordPress admin.
+
+## Shortcodes
+- `[uv_team location="osl" columns="4" highlight_primary="1"]` – output a grid of team members for a Location. Requires the `location` attribute.
+
+## Requirements
+- WordPress 6.0+
+- Polylang for multilingual quotes (optional but recommended).
+
+## Example Usage
+
+```html
+[uv_team location="bergen" columns="3"]
+```
+
+## Translation
+All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.


### PR DESCRIPTION
## Summary
- expand `uv-core` README with install steps, shortcode list, and translation guidance
- document `uv-people` shortcode usage and Polylang requirement
- update `uv-events-bridge` README with Events Calendar dependency and shortcode example
- clarify `uv-admin` plugin has no shortcodes and provide install instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d8005f8483289be3d7f0b2d8497a