### PR TITLE
Add shortcode block patterns to child theme

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -20,3 +20,27 @@ add_action('after_setup_theme', function() {
 add_action('after_setup_theme', function() {
     load_child_theme_textdomain('uv-kadence-child', get_stylesheet_directory() . '/languages');
 });
+
+// Register block patterns for shortcode blocks
+add_action('init', function() {
+    if (!function_exists('register_block_pattern')) {
+        return;
+    }
+    $patterns = [
+        'locations-grid' => __('Locations Grid', 'uv-kadence-child'),
+        'news-list'      => __('News List', 'uv-kadence-child'),
+        'activities'     => __('Activities', 'uv-kadence-child'),
+        'partners'       => __('Partners', 'uv-kadence-child'),
+        'team-grid'      => __('Team Grid', 'uv-kadence-child'),
+    ];
+    foreach ($patterns as $slug => $title) {
+        register_block_pattern(
+            'uv-kadence-child/' . $slug,
+            [
+                'title'   => $title,
+                'content' => include get_theme_file_path('patterns/' . $slug . '.php'),
+            ]
+        );
+    }
+});
+

--- a/themes/uv-kadence-child/patterns/activities.php
+++ b/themes/uv-kadence-child/patterns/activities.php
@@ -1,0 +1,3 @@
+<?php
+return '<!-- wp:shortcode -->[uv_activities columns="3"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/patterns/locations-grid.php
+++ b/themes/uv-kadence-child/patterns/locations-grid.php
@@ -1,0 +1,3 @@
+<?php
+return '<!-- wp:shortcode -->[uv_locations_grid columns="3" show_links="1"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/patterns/news-list.php
+++ b/themes/uv-kadence-child/patterns/news-list.php
@@ -1,0 +1,3 @@
+<?php
+return '<!-- wp:shortcode -->[uv_news count="3"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/patterns/partners.php
+++ b/themes/uv-kadence-child/patterns/partners.php
@@ -1,0 +1,3 @@
+<?php
+return '<!-- wp:shortcode -->[uv_partners columns="4"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/patterns/team-grid.php
+++ b/themes/uv-kadence-child/patterns/team-grid.php
@@ -1,0 +1,3 @@
+<?php
+return '<!-- wp:shortcode -->[uv_team location="osl" columns="4" highlight_primary="1"]<!-- /wp:shortcode -->';
+


### PR DESCRIPTION
## Summary
- add block pattern PHP files for locations, news, activities, partners, and team shortcodes
- register new block patterns during `init`

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `php -l themes/uv-kadence-child/patterns/locations-grid.php`
- `php -l themes/uv-kadence-child/patterns/news-list.php`
- `php -l themes/uv-kadence-child/patterns/activities.php`
- `php -l themes/uv-kadence-child/patterns/partners.php`
- `php -l themes/uv-kadence-child/patterns/team-grid.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6d8f3b7708328879903134d2209e7