### PR TITLE
Add translation template files

### DIFF
--- a/plugins/uv-admin/languages/uv-admin.pot
+++ b/plugins/uv-admin/languages/uv-admin.pot
@@ -1,0 +1,56 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uv-admin package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-admin 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-21 08:36+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: plugins/uv-admin/uv-admin.php:23 plugins/uv-admin/uv-admin.php:32
+msgid "Unge Vil Admin"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:29
+msgid "Saved."
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:36
+msgid "Docs URL"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:37
+msgid "https://sites.google.com/..."
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:39
+msgid "Save"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:46
+msgid "Unge Vil"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:90 plugins/uv-admin/uv-admin.php:106
+#: plugins/uv-admin/uv-admin.php:125
+msgid "Control Panel"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:113
+msgid "Open Team Docs"
+msgstr ""
+
+#: plugins/uv-admin/uv-admin.php:115
+#, php-format
+msgid "Tip: set your Docs URL in %sSettings → Unge Vil Admin%s."
+msgstr ""

--- a/plugins/uv-core/languages/uv-core.pot
+++ b/plugins/uv-core/languages/uv-core.pot
@@ -1,0 +1,62 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uv-core package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-core 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-21 08:36+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: plugins/uv-core/uv-core.php:14
+msgid "Locations"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:20
+msgid "Activity Types"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:26
+msgid "Partner Types"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:34
+msgid "Activities"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:43
+msgid "Partners"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:52
+msgid "Experiences"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:67 plugins/uv-core/uv-core.php:94
+msgid "Location Image"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:69 plugins/uv-core/uv-core.php:98
+msgid "Select Image"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:70
+msgid "Used on location cards."
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:246
+msgid "External URL"
+msgstr ""
+
+#: plugins/uv-core/uv-core.php:249
+msgid "Website"
+msgstr ""

--- a/plugins/uv-events-bridge/languages/uv-events-bridge.pot
+++ b/plugins/uv-events-bridge/languages/uv-events-bridge.pot
@@ -1,0 +1,18 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uv-events-bridge package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-events-bridge 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-21 08:36+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"

--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -1,0 +1,114 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uv-people package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-people 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-21 08:36+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: plugins/uv-people/uv-people.php:18 plugins/uv-people/uv-people.php:222
+msgid "Team Assignments"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:28
+msgid "Assignment"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:36
+msgid "User ID"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:38
+msgid "Location"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:40
+msgid "Select"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:45
+msgid "Role title"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:47
+msgid "Primary contact"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:48
+msgid "Order weight (lower = earlier)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:75
+msgid "Public Profile (Unge Vil)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:77
+msgid "Phone (public optional)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:80 plugins/uv-people/uv-people.php:85
+msgid "Show on profile"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:82
+msgid "Public Email (optional)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:87
+msgid "Volunteer Quote (Norwegian)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:89
+msgid "Volunteer Quote (English)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:91
+msgid "Avatar (Media Library)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:94
+msgid "Select Image"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:96
+msgid "This replaces Gravatar and uses a local image."
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:215
+msgid "Team Guide"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:216
+msgid "Quick links for editors:"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:218
+msgid "Manage Locations"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:219
+msgid "Activities"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:220
+msgid "Partners"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:221
+msgid "News Posts"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:224
+msgid "Add your own how-to video links here (edit uv-people plugin)."
+msgstr ""

--- a/themes/uv-kadence-child/languages/uv-kadence-child.pot
+++ b/themes/uv-kadence-child/languages/uv-kadence-child.pot
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the uv-kadence-child package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-kadence-child 0.1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-21 08:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: themes/uv-kadence-child/functions.php:30
+msgid "Locations Grid"
+msgstr ""
+
+#: themes/uv-kadence-child/functions.php:31
+msgid "News List"
+msgstr ""
+
+#: themes/uv-kadence-child/functions.php:32
+msgid "Activities"
+msgstr ""
+
+#: themes/uv-kadence-child/functions.php:33
+msgid "Partners"
+msgstr ""
+
+#: themes/uv-kadence-child/functions.php:34
+msgid "Team Grid"
+msgstr ""


### PR DESCRIPTION
## Summary
- add `languages/` directories and `.pot` templates for uv-kadence-child theme and uv-admin, uv-core, uv-events-bridge, and uv-people plugins

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-admin/uv-admin.php`
- `php -l plugins/uv-events-bridge/uv-events-bridge.php`
- `php -l plugins/uv-people/uv-people.php`
- `find themes/uv-kadence-child -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a6da04b2c88328af31a452c5c14a99