### PR TITLE
docs: document plugin shortcodes and usage

### DIFF
--- a/plugins/uv-admin/readme.md
+++ b/plugins/uv-admin/readme.md
@@ -4,14 +4,14 @@ UV Admin provides a branded control panel and cleaner editor UI.
 1. Upload `uv-admin` to `wp-content/plugins/`.
 2. Activate from the WordPress admin.
 
-## Shortcodes & Hooks
-This plugin does not expose public shortcodes or custom hooks.
+## Shortcodes
+This plugin does not expose public shortcodes.
+
+## Usage
+Once activated the WordPress dashboard and editor are automatically styled; no additional configuration or shortcodes are required.
 
 ## Requirements
 - WordPress 6.0+
-
-## Example Usage
-Once activated the WordPress dashboard and editor are automatically styled; no shortcodes are required.
 
 ## Translation
 All user-facing strings are translation ready. The plugin loads the `uv-admin` text domain from its `languages` directory so translations can be provided via standard WordPress `.po`/`.mo` files or translation plugins.

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -6,19 +6,28 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 
 ## Shortcodes
 - `[uv_locations_grid columns="3" show_links="1"]` – display all Locations in a card grid.
+  - `columns` (default: 3) number of columns.
+  - `show_links` (0 or 1) toggle archive links under each item.
 - `[uv_news location="osl" count="3"]` – list recent posts, optionally filtered by a Location slug.
+  - `location` (optional) Location slug.
+  - `count` (default: 3) number of posts to display.
 - `[uv_activities location="osl" columns="3"]` – grid of Activities for a Location.
+  - `location` (required) Location slug.
+  - `columns` (default: 3) number of columns.
 - `[uv_partners location="osl" type="sponsor" columns="4"]` – show Partners with optional Location or Partner Type filtering.
+  - `location` (optional) Location slug.
+  - `type` (optional) Partner Type slug.
+  - `columns` (default: 4) number of columns.
+
+## Usage
+
+```html
+[uv_news location="oslo" count="3"]
+```
 
 ## Requirements
 - WordPress 6.0+
 - Optional: Polylang for translating taxonomy terms.
-
-## Example Usage
-
-```html
-[uv_locations_grid columns="4" show_links="0"]
-```
 
 ## Translation
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -6,16 +6,18 @@ UV Events Bridge connects Locations to The Events Calendar.
 
 ## Shortcodes
 - `[uv_upcoming_events location="osl" count="5"]` – list upcoming Events optionally filtered by a Location term.
+  - `location` (optional) Location term slug.
+  - `count` (default: 5) number of events to display.
 
-## Requirements
-- WordPress 6.0+
-- The Events Calendar plugin must be active.
-
-## Example Usage
+## Usage
 
 ```html
 [uv_upcoming_events location="bergen" count="3"]
 ```
+
+## Requirements
+- WordPress 6.0+
+- The Events Calendar plugin must be active.
 
 ## Translation
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -5,17 +5,20 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
 2. Activate via the WordPress admin.
 
 ## Shortcodes
-- `[uv_team location="osl" columns="4" highlight_primary="1"]` – output a grid of team members for a Location. Requires the `location` attribute.
+- `[uv_team location="osl" columns="4" highlight_primary="1"]` – output a grid of team members for a Location.
+  - `location` (required) Location slug to filter team members.
+  - `columns` (default: 4) number of columns in the grid.
+  - `highlight_primary` (0 or 1) emphasize primary team members.
 
-## Requirements
-- WordPress 6.0+
-- Polylang for multilingual quotes (optional but recommended).
-
-## Example Usage
+## Usage
 
 ```html
 [uv_team location="bergen" columns="3"]
 ```
+
+## Requirements
+- WordPress 6.0+
+- Polylang for multilingual quotes (optional but recommended).
 
 ## Translation
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.


### PR DESCRIPTION
## Summary
- document that uv-admin has no public shortcodes and clarify usage
- expand uv-core shortcode docs with attribute descriptions and usage example
- flesh out uv-events-bridge and uv-people shortcode sections with attributes and examples

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6db84c2348328bf28d2f23d15c6ba