### PR TITLE
Load media scripts on uv_location taxonomy screens

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -59,6 +59,14 @@ add_action('init', function(){
     ]);
 });
 
+add_action('admin_enqueue_scripts', function($hook){
+    if(!in_array($hook, ['edit-tags.php','term.php'])) return;
+    $screen = get_current_screen();
+    if($screen && $screen->taxonomy === 'uv_location'){
+        wp_enqueue_media();
+    }
+});
+
 // Term image: uv_location
 add_action('uv_location_add_form_fields', function(){
     ?>


### PR DESCRIPTION
## Summary
- ensure media library scripts load when editing uv_location terms

## Testing
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df9ad48c8328b7d12993623b2dea