### PR TITLE
Specify WordPress and PHP requirements in plugin headers

### DIFF
--- a/plugins/uv-admin/uv-admin.php
+++ b/plugins/uv-admin/uv-admin.php
@@ -3,6 +3,8 @@
  * Plugin Name: UV Admin
  * Description: Branded admin UI, Control Panel, and editor-friendly dashboard for Unge Vil.
  * Version: 0.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Text Domain: uv-admin
  */
 if (!defined('ABSPATH')) exit;

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -3,6 +3,8 @@
  * Plugin Name: UV Core
  * Description: CPTs, taxonomies, term images, and lightweight shortcodes.
  * Version: 0.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Text Domain: uv-core
  */
 

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -3,6 +3,8 @@
  * Plugin Name: UV Events Bridge
  * Description: Adds uv_location taxonomy to The Events Calendar events and provides an upcoming events shortcode.
  * Version: 0.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Text Domain: uv-events-bridge
  */
 if (!defined('ABSPATH')) exit;

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -3,6 +3,8 @@
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
  * Version: 0.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Text Domain: uv-people
  */
 if (!defined('ABSPATH')) exit;


### PR DESCRIPTION
## Summary
- declare WordPress 6.0 and PHP 7.4 minimum requirements for UV core plugins

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`
- `php -l plugins/uv-events-bridge/uv-events-bridge.php`
- `php -l plugins/uv-admin/uv-admin.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0c792a08328837f8d50bb4e59af