### PR TITLE
Use user dropdown for team assignments

### DIFF
--- a/docs/CONTENT-GUIDE.md
+++ b/docs/CONTENT-GUIDE.md
@@ -19,3 +19,7 @@ Suggested order:
 2. Team (primary contact first)
 3. Local news
 4. Partners & sponsors
+
+## Team Assignments
+- Use **Team Assignments** to link a person to a Location.
+- Select the person from the dropdown list instead of entering a numeric ID.

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -36,8 +36,16 @@ add_action('add_meta_boxes_uv_team_assignment', function(){
         $locations = get_terms(['taxonomy'=>'uv_location','hide_empty'=>false]);
         ?>
         <?php wp_nonce_field('uv_ta_save', 'uv_ta_nonce'); ?>
-        <p><label><?php _e('User ID','uv-people'); ?></label>
-        <input type="number" name="uv_user_id" value="<?php echo esc_attr($user_id); ?>" style="width:100%"></p>
+        <p><label><?php _e('User','uv-people'); ?></label>
+        <?php
+            wp_dropdown_users([
+                'name'              => 'uv_user_id',
+                'selected'          => $user_id,
+                'show_option_none'  => __('Select','uv-people'),
+                'class'             => 'widefat'
+            ]);
+        ?>
+        </p>
         <p><label><?php _e('Location','uv-people'); ?></label>
         <select name="uv_location_id" style="width:100%">
             <option value=""><?php _e('Select','uv-people'); ?></option>
@@ -57,7 +65,10 @@ add_action('save_post_uv_team_assignment', function($post_id){
     if(defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if(!isset($_POST['uv_ta_nonce']) || !check_admin_referer('uv_ta_save', 'uv_ta_nonce', false)) return;
     if(!current_user_can('edit_post', $post_id)) return;
-    foreach(['uv_user_id','uv_location_id','uv_role_title','uv_order_weight'] as $key){
+    if(isset($_POST['uv_user_id'])){
+        update_post_meta($post_id, 'uv_user_id', absint($_POST['uv_user_id']));
+    }
+    foreach(['uv_location_id','uv_role_title','uv_order_weight'] as $key){
         if(isset($_POST[$key])) update_post_meta($post_id, $key, sanitize_text_field($_POST[$key]));
     }
     update_post_meta($post_id, 'uv_is_primary', isset($_POST['uv_is_primary']) ? '1' : '0');


### PR DESCRIPTION
## Summary
- Replace numeric user ID field with a user dropdown when assigning team members.
- Save the selected user ID and adjust meta box label.
- Document the new team assignment workflow.

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npx --yes markdownlint docs/CONTENT-GUIDE.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a70b2156c88328a566218a1bc049d3