### PR TITLE
Add team grid block

### DIFF
--- a/plugins/uv-people/blocks/team-grid/block.json
+++ b/plugins/uv-people/blocks/team-grid/block.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": 2,
+  "name": "uv/team-grid",
+  "title": "Team Grid",
+  "category": "widgets",
+  "icon": "groups",
+  "attributes": {
+    "location": {
+      "type": "string",
+      "default": ""
+    },
+    "columns": {
+      "type": "number",
+      "default": 4
+    }
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-people/blocks/team-grid/index.asset.php
+++ b/plugins/uv-people/blocks/team-grid/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -1,0 +1,43 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls } = wp.blockEditor;
+    const { PanelBody, SelectControl, RangeControl } = wp.components;
+    const { useSelect } = wp.data;
+
+    registerBlockType( 'uv/team-grid', {
+        edit: function( props ) {
+            const { attributes: { location, columns }, setAttributes } = props;
+            const terms = useSelect( function( select ) {
+                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            }, [] );
+            const options = terms ? terms.map( function( t ) {
+                return { label: t.name, value: t.slug };
+            } ) : [];
+            return [
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-people' ), initialOpen: true },
+                        createElement( SelectControl, {
+                            label: __( 'Location', 'uv-people' ),
+                            value: location,
+                            options: [ { label: __( 'Select', 'uv-people' ), value: '' } ].concat( options ),
+                            onChange: function( value ) { setAttributes( { location: value } ); }
+                        } ),
+                        createElement( RangeControl, {
+                            label: __( 'Columns', 'uv-people' ),
+                            min: 1,
+                            max: 6,
+                            value: columns,
+                            onChange: function( value ) { setAttributes( { columns: value } ); }
+                        } )
+                    )
+                ),
+                createElement( 'p', {}, __( 'Team Grid', 'uv-people' ) )
+            ];
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp );

--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -1,0 +1,18 @@
+.uv-team-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-team-grid .uv-person {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    text-decoration: none;
+}
+.uv-team-grid .uv-avatar img {
+    border-radius: 12px;
+    max-width: 128px;
+    height: auto;
+}
+.uv-team-grid .uv-info > *:empty {
+    display: none;
+}

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -212,6 +212,7 @@ function uv_people_get_avatar($user_id){
 
 // Shortcode: Team grid by location
 function uv_people_team_grid($atts){
+    wp_enqueue_style('uv-team-grid-style');
     $a = shortcode_atts(['location'=>'','columns'=>4,'highlight_primary'=>1], $atts);
     if(!$a['location']) return '';
     $term = get_term_by('slug', $a['location'], 'uv_location');
@@ -253,33 +254,43 @@ function uv_people_team_grid($atts){
         $pub_email = get_user_meta($uid,'uv_public_email',true);
         $classes = 'uv-person';
         if($a['highlight_primary'] && $it['primary']) $classes .= ' uv-primary-contact';
-        echo '<div class="'.esc_attr($classes).'">';
-        echo uv_people_get_avatar($uid);
+        $url = get_author_posts_url($uid);
+        echo '<a class="'.esc_attr($classes).'" href="'.esc_url($url).'">';
+        echo '<div class="uv-avatar">'.uv_people_get_avatar($uid).'</div>';
+        echo '<div class="uv-info">';
         echo '<h3>'.esc_html($name).'</h3>';
         if($it['role']) echo '<div class="uv-role">'.esc_html($it['role']).'</div>';
-        
-// choose quote by language
-$lang = function_exists('pll_current_language') ? pll_current_language('slug') : substr(get_locale(),0,2);
-$quote_nb = get_user_meta($uid,'uv_quote_nb',true);
-$quote_en = get_user_meta($uid,'uv_quote_en',true);
-$legacy_q = get_user_meta($uid,'uv_quote',true);
-$quote = ($lang==='en') ? ($quote_en ?: $quote_nb ?: $legacy_q) : ($quote_nb ?: $quote_en ?: $legacy_q);
-if($quote) echo '<div class="uv-quote">“'.esc_html($quote).'”</div>';
-// contact visibility
-$show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
-$show_email = get_user_meta($uid,'uv_show_email',true)==='1';
-if(($phone && $show_phone) || ($pub_email && $show_email)){
-    echo '<div class="uv-contact">';
-    if($phone && $show_phone) echo '<div><a href="tel:'.esc_attr($phone).'">'.esc_html($phone).'</a></div>';
-    if($pub_email && $show_email) echo '<div><a href="mailto:'.esc_attr($pub_email).'">'.esc_html($pub_email).'</a></div>';
-    echo '</div>';
-}
-echo '</div>';
+
+        // choose quote by language
+        $lang = function_exists('pll_current_language') ? pll_current_language('slug') : substr(get_locale(),0,2);
+        $quote_nb = get_user_meta($uid,'uv_quote_nb',true);
+        $quote_en = get_user_meta($uid,'uv_quote_en',true);
+        $legacy_q = get_user_meta($uid,'uv_quote',true);
+        $quote = ($lang==='en') ? ($quote_en ?: $quote_nb ?: $legacy_q) : ($quote_nb ?: $quote_en ?: $legacy_q);
+        if($quote) echo '<div class="uv-quote">“'.esc_html($quote).'”</div>';
+        // contact visibility
+        $show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
+        $show_email = get_user_meta($uid,'uv_show_email',true)==='1';
+        if(($phone && $show_phone) || ($pub_email && $show_email)){
+            echo '<div class="uv-contact">';
+            if($phone && $show_phone) echo '<div><a href="tel:'.esc_attr($phone).'">'.esc_html($phone).'</a></div>';
+            if($pub_email && $show_email) echo '<div><a href="mailto:'.esc_attr($pub_email).'">'.esc_html($pub_email).'</a></div>';
+            echo '</div>';
+        }
+        echo '</div>';
+        echo '</a>';
     }
     echo '</div>';
     return ob_get_clean();
 }
 add_shortcode('uv_team','uv_people_team_grid');
+
+// Block registration
+add_action('init', function(){
+    register_block_type(__DIR__ . '/blocks/team-grid', [
+        'render_callback' => 'uv_people_team_grid'
+    ]);
+});
 
 // Dashboard widget for team guide links
 add_action('wp_dashboard_setup', function(){


### PR DESCRIPTION
## Summary
- add Team Grid block letting editors choose location and column count
- render block via existing `uv_people_team_grid` callback and link cards to author pages
- style team grid with left-aligned avatars and hide empty fields

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `php -l plugins/uv-people/blocks/team-grid/index.asset.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7125b47708328ba30d1bfbbc93e64