### PR TITLE
Add block equivalents for uv-core shortcodes

### DIFF
--- a/plugins/uv-core/blocks/activities/block.json
+++ b/plugins/uv-core/blocks/activities/block.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": 2,
+  "name": "uv/activities",
+  "title": "Activities",
+  "category": "widgets",
+  "icon": "admin-site",
+  "attributes": {
+    "location": {"type": "string", "default": ""},
+    "columns": {"type": "number", "default": 3}
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-core/blocks/activities/index.asset.php
+++ b/plugins/uv-core/blocks/activities/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -1,0 +1,41 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls } = wp.blockEditor;
+    const { PanelBody, SelectControl, RangeControl } = wp.components;
+    const { useSelect } = wp.data;
+
+    registerBlockType( 'uv/activities', {
+        edit: function( props ) {
+            const { attributes: { location, columns }, setAttributes } = props;
+            const terms = useSelect( function( select ) {
+                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            }, [] );
+            const options = terms ? terms.map( function( t ) {
+                return { label: t.name, value: t.slug };
+            } ) : [];
+            return [
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
+                        createElement( SelectControl, {
+                            label: __( 'Location', 'uv-core' ),
+                            value: location,
+                            options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( options ),
+                            onChange: function( value ) { setAttributes( { location: value } ); }
+                        } ),
+                        createElement( RangeControl, {
+                            label: __( 'Columns', 'uv-core' ),
+                            min: 1,
+                            max: 6,
+                            value: columns,
+                            onChange: function( value ) { setAttributes( { columns: value } ); }
+                        } )
+                    )
+                ),
+                createElement( 'p', {}, __( 'Activities', 'uv-core' ) )
+            ];
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp );

--- a/plugins/uv-core/blocks/activities/style.css
+++ b/plugins/uv-core/blocks/activities/style.css
@@ -1,0 +1,7 @@
+.uv-card-list {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-card {
+    list-style: none;
+}

--- a/plugins/uv-core/blocks/locations-grid/block.json
+++ b/plugins/uv-core/blocks/locations-grid/block.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": 2,
+  "name": "uv/locations-grid",
+  "title": "Locations Grid",
+  "category": "widgets",
+  "icon": "location-alt",
+  "attributes": {
+    "columns": {"type": "number", "default": 3},
+    "show_links": {"type": "boolean", "default": true}
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-core/blocks/locations-grid/index.asset.php
+++ b/plugins/uv-core/blocks/locations-grid/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -1,0 +1,33 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls } = wp.blockEditor;
+    const { PanelBody, RangeControl, ToggleControl } = wp.components;
+
+    registerBlockType( 'uv/locations-grid', {
+        edit: function( props ) {
+            const { attributes: { columns, show_links }, setAttributes } = props;
+            return [
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
+                        createElement( RangeControl, {
+                            label: __( 'Columns', 'uv-core' ),
+                            min: 1,
+                            max: 6,
+                            value: columns,
+                            onChange: function( value ) { setAttributes( { columns: value } ); }
+                        } ),
+                        createElement( ToggleControl, {
+                            label: __( 'Show Links', 'uv-core' ),
+                            checked: show_links,
+                            onChange: function( value ) { setAttributes( { show_links: value } ); }
+                        } )
+                    )
+                ),
+                createElement( 'p', {}, __( 'Locations Grid', 'uv-core' ) )
+            ];
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp );

--- a/plugins/uv-core/blocks/locations-grid/style.css
+++ b/plugins/uv-core/blocks/locations-grid/style.css
@@ -1,0 +1,7 @@
+.uv-card-list {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-card {
+    list-style: none;
+}

--- a/plugins/uv-core/blocks/news/block.json
+++ b/plugins/uv-core/blocks/news/block.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": 2,
+  "name": "uv/news",
+  "title": "News",
+  "category": "widgets",
+  "icon": "megaphone",
+  "attributes": {
+    "location": {"type": "string", "default": ""},
+    "count": {"type": "number", "default": 3}
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-core/blocks/news/index.asset.php
+++ b/plugins/uv-core/blocks/news/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -1,0 +1,41 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls } = wp.blockEditor;
+    const { PanelBody, SelectControl, RangeControl } = wp.components;
+    const { useSelect } = wp.data;
+
+    registerBlockType( 'uv/news', {
+        edit: function( props ) {
+            const { attributes: { location, count }, setAttributes } = props;
+            const terms = useSelect( function( select ) {
+                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            }, [] );
+            const options = terms ? terms.map( function( t ) {
+                return { label: t.name, value: t.slug };
+            } ) : [];
+            return [
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
+                        createElement( SelectControl, {
+                            label: __( 'Location', 'uv-core' ),
+                            value: location,
+                            options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( options ),
+                            onChange: function( value ) { setAttributes( { location: value } ); }
+                        } ),
+                        createElement( RangeControl, {
+                            label: __( 'Count', 'uv-core' ),
+                            min: 1,
+                            max: 10,
+                            value: count,
+                            onChange: function( value ) { setAttributes( { count: value } ); }
+                        } )
+                    )
+                ),
+                createElement( 'p', {}, __( 'News', 'uv-core' ) )
+            ];
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp );

--- a/plugins/uv-core/blocks/news/style.css
+++ b/plugins/uv-core/blocks/news/style.css
@@ -1,0 +1,7 @@
+.uv-card-list {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-card {
+    list-style: none;
+}

--- a/plugins/uv-core/blocks/partners/block.json
+++ b/plugins/uv-core/blocks/partners/block.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": 2,
+  "name": "uv/partners",
+  "title": "Partners",
+  "category": "widgets",
+  "icon": "heart",
+  "attributes": {
+    "location": {"type": "string", "default": ""},
+    "type": {"type": "string", "default": ""},
+    "columns": {"type": "number", "default": 4}
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-core/blocks/partners/index.asset.php
+++ b/plugins/uv-core/blocks/partners/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -1,0 +1,49 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls } = wp.blockEditor;
+    const { PanelBody, SelectControl, RangeControl } = wp.components;
+    const { useSelect } = wp.data;
+
+    registerBlockType( 'uv/partners', {
+        edit: function( props ) {
+            const { attributes: { location, type, columns }, setAttributes } = props;
+            const locations = useSelect( function( select ) {
+                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            }, [] );
+            const types = useSelect( function( select ) {
+                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_partner_type', { per_page: -1 } );
+            }, [] );
+            const locationOptions = locations ? locations.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
+            const typeOptions = types ? types.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
+            return [
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
+                        createElement( SelectControl, {
+                            label: __( 'Location', 'uv-core' ),
+                            value: location,
+                            options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( locationOptions ),
+                            onChange: function( value ) { setAttributes( { location: value } ); }
+                        } ),
+                        createElement( SelectControl, {
+                            label: __( 'Type', 'uv-core' ),
+                            value: type,
+                            options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( typeOptions ),
+                            onChange: function( value ) { setAttributes( { type: value } ); }
+                        } ),
+                        createElement( RangeControl, {
+                            label: __( 'Columns', 'uv-core' ),
+                            min: 1,
+                            max: 6,
+                            value: columns,
+                            onChange: function( value ) { setAttributes( { columns: value } ); }
+                        } )
+                    )
+                ),
+                createElement( 'p', {}, __( 'Partners', 'uv-core' ) )
+            ];
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp );

--- a/plugins/uv-core/blocks/partners/style.css
+++ b/plugins/uv-core/blocks/partners/style.css
@@ -1,0 +1,7 @@
+.uv-card-list {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-card {
+    list-style: none;
+}

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -267,3 +267,19 @@ add_action('save_post_uv_partner', function($post_id){
         update_post_meta($post_id, 'uv_partner_url', esc_url_raw($_POST['uv_partner_url']));
     }
 });
+
+// Block registration
+add_action('init', function(){
+    register_block_type(__DIR__ . '/blocks/locations-grid', [
+        'render_callback' => 'uv_core_locations_grid'
+    ]);
+    register_block_type(__DIR__ . '/blocks/news', [
+        'render_callback' => 'uv_core_posts_news'
+    ]);
+    register_block_type(__DIR__ . '/blocks/activities', [
+        'render_callback' => 'uv_core_activities'
+    ]);
+    register_block_type(__DIR__ . '/blocks/partners', [
+        'render_callback' => 'uv_core_partners'
+    ]);
+});


### PR DESCRIPTION
## Summary
- register Locations Grid, News, Activities and Partners blocks with server-side rendering
- add block metadata and editor controls for shortcode attributes
- provide minimal styles and script dependencies for editor use

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a72fa6659c8328bd86509c8d1cd646