### PR TITLE
Support bilingual role titles for team assignments

### DIFF
--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -37,8 +37,12 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: plugins/uv-people/uv-people.php:45
-msgid "Role title"
+#: plugins/uv-people/uv-people.php:61
+msgid "Role title (Norwegian)"
+msgstr ""
+
+#: plugins/uv-people/uv-people.php:63
+msgid "Role title (English)"
 msgstr ""
 
 #: plugins/uv-people/uv-people.php:47


### PR DESCRIPTION
## Summary
- Add separate Norwegian and English role fields to team assignment meta box
- Persist new bilingual role titles and render language-specific role text on team grid
- Update translation template with strings for new role fields

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `msgfmt --check -o /dev/null plugins/uv-people/languages/uv-people.pot`


------
https://chatgpt.com/codex/tasks/task_e_68a730f7e39c83289cca51a44b678914