### PR TITLE
Add related post meta to experiences

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -268,6 +268,32 @@ add_action('save_post_uv_partner', function($post_id){
     }
 });
 
+// Related post meta box for experiences
+add_action('add_meta_boxes_uv_experience', function(){
+    add_meta_box('uv_related_post', __('Related Post','uv-core'), function($post){
+        wp_nonce_field('uv_related_post_action', 'uv_related_post_nonce');
+        $selected = get_post_meta($post->ID, 'uv_related_post', true);
+        wp_dropdown_pages([
+            'post_type' => 'post',
+            'name' => 'uv_related_post',
+            'selected' => $selected,
+            'show_option_none' => __('— None —', 'uv-core'),
+        ]);
+    }, 'side');
+});
+
+add_action('save_post_uv_experience', function($post_id){
+    if(!isset($_POST['uv_related_post_nonce'])) return;
+    if(!current_user_can('edit_post', $post_id)) return;
+    check_admin_referer('uv_related_post_action', 'uv_related_post_nonce');
+    $val = isset($_POST['uv_related_post']) ? intval($_POST['uv_related_post']) : 0;
+    if($val){
+        update_post_meta($post_id, 'uv_related_post', $val);
+    }else{
+        delete_post_meta($post_id, 'uv_related_post');
+    }
+});
+
 // Block registration
 add_action('init', function(){
     register_block_type(__DIR__ . '/blocks/locations-grid', [

--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Template for single UV Experience posts.
+ */
+
+get_header();
+
+if ( have_posts() ) :
+    ?>
+    <main id="primary" class="site-main">
+    <?php
+    while ( have_posts() ) :
+        the_post();
+        ?>
+        <article <?php post_class(); ?>>
+            <h1><?php the_title(); ?></h1>
+            <div>
+                <?php the_content(); ?>
+            </div>
+            <?php
+            $related = get_post_meta( get_the_ID(), 'uv_related_post', true );
+            if ( $related ) :
+                ?>
+                <div class="uv-related-post">
+                    <h2><?php esc_html_e( 'Related Post', 'uv-kadence-child' ); ?></h2>
+                    <a href="<?php echo esc_url( get_permalink( $related ) ); ?>">
+                        <?php echo esc_html( get_the_title( $related ) ); ?>
+                    </a>
+                </div>
+                <?php
+            endif;
+            ?>
+        </article>
+        <?php
+    endwhile;
+    ?>
+    </main>
+    <?php
+endif;
+
+get_footer();


### PR DESCRIPTION
## Summary
- add meta box for selecting a related post on UV Experience edit screens and save to `uv_related_post`
- display related post link on the single UV Experience template

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l themes/uv-kadence-child/single-uv_experience.php`


------
https://chatgpt.com/codex/tasks/task_e_68a732e191608328ba0f357a80c7ccfd