### PR TITLE
Render custom Control Panel page and add display name shortcode

### DIFF
--- a/docs/UNGEVIL-ADMIN.md
+++ b/docs/UNGEVIL-ADMIN.md
@@ -12,3 +12,6 @@ Go to **Settings → Unge Vil Admin**, paste your Google Sites URL (or any docs 
 
 ## Customize Logo
 Replace `themes/uv-kadence-child/assets/img/logo.svg` with your logo (same filename) to update the login screen and Control Panel header.
+
+## Design Control Panel Page
+Create a normal WordPress page and build its layout with Kadence blocks. Set its ID in the `uv_admin_control_panel_page_id` option so the plugin renders that page inside the Control Panel screen. Use the `[uv_display_name]` shortcode anywhere in the page to greet the current user.

--- a/plugins/uv-admin/readme.md
+++ b/plugins/uv-admin/readme.md
@@ -5,10 +5,10 @@ UV Admin provides a branded control panel and cleaner editor UI.
 2. Activate from the WordPress admin.
 
 ## Shortcodes
-This plugin does not expose public shortcodes.
+`[uv_display_name]` – outputs the current user's display name.
 
 ## Usage
-Once activated the WordPress dashboard and editor are automatically styled; no additional configuration or shortcodes are required.
+Once activated the WordPress dashboard and editor are automatically styled. Set the `uv_admin_control_panel_page_id` option to use a custom page for the Control Panel. That page can include the `[uv_display_name]` shortcode for personalized greetings.
 
 ## Requirements
 - WordPress 6.0+

--- a/plugins/uv-admin/uv-admin.php
+++ b/plugins/uv-admin/uv-admin.php
@@ -93,6 +93,17 @@ add_action('admin_menu', function(){
 });
 
 function uv_admin_control_panel(){
+    $page_id = intval( get_option('uv_admin_control_panel_page_id', 0) );
+    if ( $page_id ) {
+        $page = get_post( $page_id );
+        if ( $page instanceof \WP_Post ) {
+            echo '<div class="wrap uv-control-panel">';
+            echo apply_filters('the_content', $page->post_content);
+            echo '</div>';
+            return;
+        }
+    }
+
     $docs = uv_admin_get_docs_url();
     $cards = [
         ['News','edit.php','dashicons-megaphone'],
@@ -105,10 +116,10 @@ function uv_admin_control_panel(){
     ];
     if(post_type_exists('tribe_events')) $cards[] = ['Events','edit.php?post_type=tribe_events','dashicons-calendar-alt'];
     echo '<div class="wrap uv-control-panel">';
-    echo '<div class="uvcp-header"><img alt="Unge Vil" src="' . esc_url(get_stylesheet_directory_uri().'/assets/img/logo.svg') . '"><h1>Unge Vil — ' . esc_html( __('Control Panel','uv-admin') ) . '</h1></div>';
+    echo '<div class="uvcp-header"><img alt="Unge Vil" src="' . esc_url(get_stylesheet_directory_uri().'/assets/img/logo.svg') . '\"><h1>Unge Vil — ' . esc_html( __('Control Panel','uv-admin') ) . '</h1></div>';
     echo '<div class="uvcp-grid">';
     foreach($cards as $c){
-        echo '<a class="uvcp-card" href="' . esc_url( admin_url($c[1]) ) . '"><span class="dashicons ' . esc_attr($c[2]) . '"></span><strong>' . esc_html( __($c[0], 'uv-admin') ) . '</strong></a>';
+        echo '<a class="uvcp-card" href="' . esc_url( admin_url($c[1]) ) . '\"><span class="dashicons ' . esc_attr($c[2]) . '\"></span><strong>' . esc_html( __($c[0], 'uv-admin') ) . '</strong></a>';
     }
     echo '</div>';
     if($docs){
@@ -118,6 +129,12 @@ function uv_admin_control_panel(){
     }
     echo '</div>';
 }
+
+add_shortcode('uv_display_name', function(){
+    $user = wp_get_current_user();
+    return $user && $user->exists() ? esc_html( $user->display_name ) : '';
+});
+
 
 // Admin bar shortcut
 add_action('admin_bar_menu', function($bar){


### PR DESCRIPTION
## Summary
- Allow `uv_admin_control_panel()` to load content from a page ID option and filter through `the_content`
- Introduce `[uv_display_name]` shortcode to show the current user's display name
- Document designing the Control Panel page with Kadence blocks and using the shortcode

## Testing
- `php -l plugins/uv-admin/uv-admin.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a73390fb3c83288c4c880ca3f55d30