### PR TITLE
Load UV Core textdomain on plugins_loaded

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -10,6 +10,10 @@
 
 if (!defined('ABSPATH')) exit;
 
+add_action('plugins_loaded', function(){
+    load_plugin_textdomain('uv-core', false, dirname(plugin_basename(__FILE__)) . '/languages');
+});
+
 add_action('init', function(){
     // Taxonomies
     register_taxonomy('uv_location', ['post','uv_activity','uv_partner','uv_experience'], [


### PR DESCRIPTION
## Summary
- Load UV Core textdomain during `plugins_loaded` to make translations available

## Testing
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68a73821fd588328a9b7fb13d681880b