### PR TITLE
Ensure shortcode queries reset global post data

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -166,8 +166,8 @@ function uv_core_posts_news($atts){
             echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div></a></li>';
         }
         echo '</ul>';
-        wp_reset_postdata();
     }
+    wp_reset_postdata();
     return ob_get_clean();
 }
 add_shortcode('uv_news','uv_core_posts_news');
@@ -193,8 +193,8 @@ function uv_core_activities($atts){
             echo '</div></a></li>';
         }
         echo '</ul>';
-        wp_reset_postdata();
     }
+    wp_reset_postdata();
     return ob_get_clean();
 }
 add_shortcode('uv_activities','uv_core_activities');
@@ -225,8 +225,8 @@ function uv_core_partners($atts){
             echo '</div></a></li>';
         }
         echo '</ul>';
-        wp_reset_postdata();
     }
+    wp_reset_postdata();
     return ob_get_clean();
 }
 add_shortcode('uv_partners','uv_core_partners');

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -47,8 +47,8 @@ function uv_upcoming_events_sc($atts){
             echo '</div></a></li>';
         }
         echo '</ul>';
-        wp_reset_postdata();
     }
+    wp_reset_postdata();
     return ob_get_clean();
 }
 add_shortcode('uv_upcoming_events','uv_upcoming_events_sc');


### PR DESCRIPTION
## Summary
- Move `wp_reset_postdata()` outside conditional blocks in shortcode functions to always restore globals.
- Ensure upcoming events shortcode also resets post data after custom query.

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-events-bridge/uv-events-bridge.php`


------
https://chatgpt.com/codex/tasks/task_e_68abf258fdb48328a8d422af96478ced