### PR TITLE
docs: add module usage guides

### DIFF
--- a/docs/BLOCKS.md
+++ b/docs/BLOCKS.md
@@ -1,0 +1,32 @@
+# Blocks
+
+## Locations Grid
+- **Block name:** `uv/locations-grid`
+- **Settings:**
+  - `columns` (number, default 3)
+  - `show_links` (boolean, default true)
+
+## News
+- **Block name:** `uv/news`
+- **Settings:**
+  - `location` (string, default empty)
+  - `count` (number, default 3)
+
+## Activities
+- **Block name:** `uv/activities`
+- **Settings:**
+  - `location` (string, default empty)
+  - `columns` (number, default 3)
+
+## Partners
+- **Block name:** `uv/partners`
+- **Settings:**
+  - `location` (string, default empty)
+  - `type` (string, default empty)
+  - `columns` (number, default 4)
+
+## Team Grid
+- **Block name:** `uv/team-grid`
+- **Settings:**
+  - `location` (string, default empty)
+  - `columns` (number, default 4)

--- a/docs/EXPERIENCES.md
+++ b/docs/EXPERIENCES.md
@@ -1,0 +1,13 @@
+# Experiences
+
+## Adding an Experience
+1. In the WordPress dashboard, go to **Experiences → Add New**.
+2. Enter a title, content, and optional featured image and excerpt.
+3. Assign a **Location** term if relevant.
+4. Publish the Experience.
+
+## Linking to a Blog Post
+When editing an Experience, use the **Related Post** meta box in the sidebar to choose an existing blog post. Select **— None —** if no blog post should be connected.
+
+## Linking to a WordPress User
+Experiences do not include a dedicated user selector. If needed, you can store a user reference in a custom field or mention the user in the content. Team visibility is managed separately through User → Location assignments.

--- a/docs/USER-LOCATIONS.md
+++ b/docs/USER-LOCATIONS.md
@@ -1,0 +1,11 @@
+# User Locations
+
+## Assigning Locations to a User
+1. Edit a user profile in the WordPress dashboard.
+2. In the **Public Profile (Unge Vil)** section, use the **Locations** multi-select to choose one or more departments/locations.
+3. Save the profile.
+
+The plugin stores the selected locations on the user and creates or removes **Team Assignment** posts as needed.
+
+## Editing Assignments
+Assignments can also be managed directly via **Team Assignments** in the admin menu for fine‑grained control (role titles, order, primary contact).


### PR DESCRIPTION
## Summary
- add instructions for creating and linking Experience posts
- document assigning users to multiple locations
- summarize block types and their settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf318154c8328808de329db8df5db