### PR TITLE
Add team member template and experience links

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -299,7 +299,8 @@ function uv_people_team_grid($atts){
         $email = get_the_author_meta('user_email', $uid);
         $classes = 'uv-person';
         if($a['highlight_primary'] && $it['primary']) $classes .= ' uv-primary-contact';
-        $url = get_author_posts_url($uid);
+        // Link each card to custom team template
+        $url = add_query_arg('team', '1', get_author_posts_url($uid));
         echo '<a class="'.esc_attr($classes).'" href="'.esc_url($url).'">';
         echo '<div class="uv-avatar">'.uv_people_get_avatar($uid).'</div>';
         echo '<div class="uv-info">';

--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Template for displaying individual team members.
+ * Triggered on author archive URLs when the `team` query var is present.
+ */
+
+get_header();
+
+$user = get_queried_object();
+if ($user instanceof WP_User) :
+    $uid  = $user->ID;
+    $lang = function_exists('pll_current_language') ? pll_current_language('slug') : substr(get_locale(), 0, 2);
+    ?>
+    <article class="uv-team-member">
+        <header class="uv-member-header">
+            <h1><?php echo esc_html($user->display_name); ?></h1>
+            <?php if (function_exists('uv_people_get_avatar')) : ?>
+                <div class="uv-avatar"><?php echo uv_people_get_avatar($uid); ?></div>
+            <?php endif; ?>
+        </header>
+        <?php
+        $bio = get_the_author_meta('description', $uid);
+        if ($bio) {
+            echo '<div class="uv-bio">' . wpautop($bio) . '</div>';
+        }
+
+        $quote_nb = get_user_meta($uid, 'uv_quote_nb', true);
+        $quote_en = get_user_meta($uid, 'uv_quote_en', true);
+        $legacy_q = get_user_meta($uid, 'uv_quote', true);
+        $quote    = ($lang === 'en') ? ($quote_en ?: $quote_nb ?: $legacy_q) : ($quote_nb ?: $quote_en ?: $legacy_q);
+        if ($quote) {
+            echo '<blockquote class="uv-quote">“' . esc_html($quote) . '”</blockquote>';
+        }
+
+        $phone      = get_user_meta($uid, 'uv_phone', true);
+        $show_phone = get_user_meta($uid, 'uv_show_phone', true) === '1';
+        $email      = get_the_author_meta('user_email', $uid);
+        if (($phone && $show_phone) || $email) {
+            echo '<div class="uv-contact">';
+            if ($phone && $show_phone) {
+                echo '<div><a href="tel:' . esc_attr($phone) . '">' . esc_html($phone) . '</a></div>';
+            }
+            if ($email) {
+                echo '<div><a href="mailto:' . esc_attr($email) . '">' . esc_html($email) . '</a></div>';
+            }
+            echo '</div>';
+        }
+
+        if (function_exists('uv_core_get_experiences_for_user')) {
+            $experiences = uv_core_get_experiences_for_user($uid);
+            if ($experiences) {
+                echo '<h2>' . esc_html__('Experiences', 'uv-kadence-child') . '</h2>';
+                echo '<ul class="uv-experiences">';
+                foreach ($experiences as $exp) {
+                    echo '<li><a href="' . esc_url(get_permalink($exp)) . '">' . esc_html(get_the_title($exp)) . '</a></li>';
+                }
+                echo '</ul>';
+            }
+        }
+        ?>
+    </article>
+<?php endif; ?>
+
+<?php get_footer();

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -54,3 +54,14 @@ add_action('init', function() {
     }
 });
 
+// Use custom team author template when ?team is present on author URLs
+add_filter('author_template', function($template) {
+    if (isset($_GET['team'])) {
+        $team_template = locate_template('author-team.php');
+        if ($team_template) {
+            return $team_template;
+        }
+    }
+    return $template;
+});
+


### PR DESCRIPTION
## Summary
- Add author-team template to display user metadata and related experiences
- Link team grid cards to the new team template
- Route author pages with `?team` to the custom template

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68abf81ac97c83288b0238c24fc18cc1