### PR TITLE
Store optional related post ID for experiences

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -258,6 +258,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'name' => 'uv_related_post',
             'selected' => $selected,
             'show_option_none' => __('— None —', 'uv-core'),
+            'option_none_value' => 0,
         ]);
     }, 'side');
 });
@@ -266,7 +267,7 @@ add_action('save_post_uv_experience', function($post_id){
     if(!isset($_POST['uv_related_post_nonce'])) return;
     if(!current_user_can('edit_post', $post_id)) return;
     check_admin_referer('uv_related_post_action', 'uv_related_post_nonce');
-    $val = isset($_POST['uv_related_post']) ? intval($_POST['uv_related_post']) : 0;
+    $val = isset($_POST['uv_related_post']) ? absint($_POST['uv_related_post']) : 0;
     if($val){
         update_post_meta($post_id, 'uv_related_post', $val);
     }else{
@@ -307,6 +308,13 @@ add_action('save_post_uv_experience', function($post_id){
 
 // Register meta for querying
 add_action('init', function(){
+    register_post_meta('uv_experience', 'uv_related_post', [
+        'single' => true,
+        'type' => 'integer',
+        'show_in_rest' => true,
+        'sanitize_callback' => 'absint',
+        'auth_callback' => function(){ return current_user_can('edit_posts'); },
+    ]);
     register_post_meta('uv_experience', 'uv_experience_users', [
         'single' => false,
         'type' => 'integer',

--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -18,7 +18,7 @@ if ( have_posts() ) :
                 <?php the_content(); ?>
             </div>
             <?php
-            $related = get_post_meta( get_the_ID(), 'uv_related_post', true );
+            $related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );
             if ( $related ) :
                 ?>
                 <div class="uv-related-post">


### PR DESCRIPTION
## Summary
- register and sanitize `uv_related_post` meta for experiences
- only show related post link when ID is set

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l themes/uv-kadence-child/single-uv_experience.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac000b73e08328a8914cd70a453271