### PR TITLE
Add partner display options for partners block

### DIFF
--- a/docs/BLOCKS.md
+++ b/docs/BLOCKS.md
@@ -24,6 +24,7 @@
   - `location` (string, default empty)
   - `type` (string, default empty)
   - `columns` (number, default 4)
+- **Partner display options:** `logo_only`, `logo_title`, `circle_title`, `icon_title`
 
 ## Team Grid
 - **Block name:** `uv/team-grid`

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -18,6 +18,7 @@ UV Core registers CPTs, taxonomies, and shortcodes.
   - `location` (optional) Location slug.
   - `type` (optional) Partner Type slug.
   - `columns` (default: 4) number of columns.
+  - Each Partner post has a **Display** option: `logo_only`, `logo_title`, `circle_title`, or `icon_title`.
 
 ## Usage
 
@@ -33,6 +34,8 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.
 
 ## Changelog
+### 0.3.0
+- Added partner display meta field with logo and title layout options.
 ### 0.2.0
 - Enhanced shortcode parameters and updated documentation.
 ### 0.1.0


### PR DESCRIPTION
## Summary
- add `uv_partner_display` meta field with display choices: logo only, logo/title, circle/title, icon/title
- update partners shortcode and block to render different markup based on display option
- document partner display modes in docs and plugin readme

## Testing
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac01b6f7688328b6b5ddcaef025d45