### PR TITLE
docs: add editor guide for content management

### DIFF
--- a/docs/EDITOR-GUIDE.md
+++ b/docs/EDITOR-GUIDE.md
@@ -1,0 +1,31 @@
+# Editor Guide
+
+Simple steps for managing common content types in the WordPress dashboard.
+
+## Experiences
+1. Go to **Experiences → Add New**.
+2. Enter a title and main content.
+3. Optionally set a **Featured image** and **Excerpt**.
+4. In the **Location** box choose a location if the experience belongs to one.
+5. Publish the Experience.
+
+## Partners
+1. Go to **Partners → Add New**.
+2. Add a title and description.
+3. Use **Set featured image** for the partner logo if available.
+4. In the sidebar, assign a **Location** and, if needed, a **Partner Type**.
+5. In the **External URL** field, paste the partner's website.
+6. Publish the Partner.
+
+## Team Members
+1. Go to **Users → Add New** (or edit an existing user).
+2. Enter the person's details and assign an appropriate role.
+3. In the **Public Profile (Unge Vil)** section, add a profile image and contact info.
+4. Use the **Locations** selector to link the person to one or more locations.
+5. Save the profile. Fine‑tune roles or order under **Team Assignments** if needed.
+
+## News / Blog Posts
+1. Go to **Posts → Add New**.
+2. Write the title, content, and set a featured image if desired.
+3. In the **Categories** panel, choose the category that matches the location name (add a new category if required).
+4. Publish the post.


### PR DESCRIPTION
## Summary
- add a simple editor guide covering experiences, partners, team members, and news

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac020683f08328a6b321642ef31af6