### PR TITLE
Improve accessibility and contrast across templates and blocks

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -137,7 +137,7 @@ function uv_core_locations_grid($atts){
         $out .= '<li class="uv-card">';
         if($a['show_links']) $out .= '<a href="'.esc_url($url).'">';
         $out .= $img;
-        $out .= '<div class="uv-card-body"><strong>'.esc_html($t->name).'</strong></div>';
+        $out .= '<div class="uv-card-body"><h3>'.esc_html($t->name).'</h3></div>';
         if($a['show_links']) $out .= '</a>';
         $out .= '</li>';
     }
@@ -163,7 +163,7 @@ function uv_core_posts_news($atts){
         while($q->have_posts()){ $q->the_post();
             echo '<li class="uv-card"><a href="'.esc_url(get_permalink()).'">';
             if(has_post_thumbnail()) the_post_thumbnail('uv_card',['alt'=>esc_attr(get_the_title())]);
-            echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div></a></li>';
+            echo '<div class="uv-card-body"><h3>'.esc_html(get_the_title()).'</h3></div></a></li>';
         }
         echo '</ul>';
     }
@@ -188,7 +188,7 @@ function uv_core_activities($atts){
         while($q->have_posts()){ $q->the_post();
             echo '<li class="uv-card"><a href="'.esc_url(get_permalink()).'">';
             if(has_post_thumbnail()) the_post_thumbnail('uv_card',['alt'=>esc_attr(get_the_title())]);
-            echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong>';
+            echo '<div class="uv-card-body"><h3>'.esc_html(get_the_title()).'</h3>';
             if(has_excerpt()) echo '<div>'.esc_html(get_the_excerpt()).'</div>';
             echo '</div></a></li>';
         }

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -244,12 +244,14 @@ function uv_people_profile_save($user_id){
 
 // Helper: get user avatar URL by our field
 function uv_people_get_avatar($user_id){
-    $id = get_user_meta($user_id,'uv_avatar_id',true);
+    $id   = get_user_meta($user_id,'uv_avatar_id',true);
+    $name = get_the_author_meta('display_name', $user_id);
+    $alt  = $name ? esc_attr($name) : '';
     if($id){
-        $img = wp_get_attachment_image($id, 'uv_avatar', false, ['alt'=>'']);
+        $img = wp_get_attachment_image($id, 'uv_avatar', false, ['alt'=>$alt]);
         return $img;
     }
-    return get_avatar($user_id); // fallback
+    return get_avatar($user_id, 96, '', $alt); // fallback
 }
 
 // Shortcode: Team grid by location
@@ -301,7 +303,8 @@ function uv_people_team_grid($atts){
         if($a['highlight_primary'] && $it['primary']) $classes .= ' uv-primary-contact';
         // Link each card to custom team template
         $url = add_query_arg('team', '1', get_author_posts_url($uid));
-        echo '<a class="'.esc_attr($classes).'" href="'.esc_url($url).'">';
+        $label = sprintf(__('View profile for %s','uv-people'), $name);
+        echo '<a class="'.esc_attr($classes).'" href="'.esc_url($url).'" aria-label="'.esc_attr($label).'">';
         echo '<div class="uv-avatar">'.uv_people_get_avatar($uid).'</div>';
         echo '<div class="uv-info">';
         echo '<h3>'.esc_html($name).'</h3>';

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -1,19 +1,20 @@
 :root{
-  --uv-purple:#9900ff;
+  --uv-purple:#7a00cc;
   --uv-radius:16px;
 }
 .uv-card-list{list-style:none;display:grid;gap:1rem;padding:0}
 .uv-card{border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);overflow:hidden;background:#fff}
 .uv-card a{display:block;text-decoration:none}
 .uv-card .uv-card-body{padding:12px}
-.uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:2px;transition:outline-offset .2s ease-in-out}
+.uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{outline:3px solid var(--uv-purple)}
 .uv-team-grid{display:grid;gap:1rem}
 @media(min-width:768px){.uv-team-grid{grid-template-columns:repeat(3,1fr)}}
 @media(min-width:1024px){.uv-team-grid{grid-template-columns:repeat(4,1fr)}}
 .uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem}
 .uv-person h3{margin:.3rem 0 0;font-size:1.1rem}
-.uv-person .uv-role{font-size:.95rem;opacity:.8}
-.uv-person .uv-quote{margin-top:.5rem;font-style:italic}
+.uv-person .uv-role{font-size:.95rem;color:#555}
+.uv-person .uv-quote{margin-top:.5rem;font-style:italic;color:#333}
+.uv-card-body h3{margin:0;font-size:1rem}
 
-body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}

--- a/themes/uv-kadence-child/taxonomy-uv_location.php
+++ b/themes/uv-kadence-child/taxonomy-uv_location.php
@@ -27,8 +27,11 @@ if ( $term && ! is_wp_error( $term ) ) {
                 </div>
             </div>
 
+            <h2><?php esc_html_e( 'Team', 'uv-kadence-child' ); ?></h2>
             <?php echo do_shortcode( '[uv_team location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <h2><?php esc_html_e( 'News', 'uv-kadence-child' ); ?></h2>
             <?php echo do_shortcode( '[uv_news location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <h2><?php esc_html_e( 'Activities', 'uv-kadence-child' ); ?></h2>
             <?php echo do_shortcode( '[uv_activities location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         </article>
     </main>


### PR DESCRIPTION
## Summary
- add section headings on UV Location template for clearer hierarchy
- enhance card shortcodes with heading tags
- supply avatar alt text and ARIA labels on team grid links
- improve theme contrast and focus outline styles

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`
- `php -l themes/uv-kadence-child/taxonomy-uv_location.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0324e32083288a4e1e07a70bd2d9