### PR TITLE
Escape option labels in partner display meta box

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -265,7 +265,7 @@ add_action('add_meta_boxes_uv_partner', function(){
         $val = get_post_meta($post->ID, 'uv_partner_display', true);
         if(!$val) $val = 'logo_title';
         wp_nonce_field('uv_partner_display_action', 'uv_partner_display_nonce');
-        echo '<p><label class="screen-reader-text" for="uv_partner_display">'.__('Display','uv-core').'</label>';
+        echo '<p><label class="screen-reader-text" for="uv_partner_display">'.esc_html__('Display','uv-core').'</label>';
         echo '<select id="uv_partner_display" name="uv_partner_display">';
         $opts = [
             'logo_only'   => __('Logo only','uv-core'),
@@ -274,7 +274,7 @@ add_action('add_meta_boxes_uv_partner', function(){
             'icon_title'  => __('Icon & title','uv-core'),
         ];
         foreach($opts as $k=>$label){
-            echo '<option value="'.$k.'"'.selected($val,$k,false).'>'.$label.'</option>';
+            echo '<option value="'.esc_attr($k).'"'.selected($val,$k,false).'>'.esc_html($label).'</option>';
         }
         echo '</select></p>';
     }, 'side');


### PR DESCRIPTION
## Summary
- escape partner display meta box label
- sanitize option labels in the partner display meta box

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test` *(fails: could not read package.json)*
- `composer test` *(fails: command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac06bceeb8832880b803c2841600e7