### PR TITLE
Sanitize team member biography output

### DIFF
--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -19,9 +19,9 @@ if ($user instanceof WP_User) :
             <?php endif; ?>
         </header>
         <?php
-        $bio = get_the_author_meta('description', $uid);
-        if ($bio) {
-            echo '<div class="uv-bio">' . wpautop($bio) . '</div>';
+        $bio = get_the_author_meta( 'description', $uid );
+        if ( $bio ) {
+            echo '<div class="uv-bio">' . wp_kses_post( wpautop( $bio ) ) . '</div>';
         }
 
         $quote_nb = get_user_meta($uid, 'uv_quote_nb', true);


### PR DESCRIPTION
## Summary
- Sanitize team member biographies using `wp_kses_post` to permit only safe HTML.

## Testing
- `php -l themes/uv-kadence-child/author-team.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac09c7f3fc8328b07a2216e05bd686