### PR TITLE
Sanitize shortcode taxonomy inputs

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -150,10 +150,11 @@ function uv_core_posts_news($atts){
     $a = shortcode_atts(['location'=>'','count'=>3], $atts);
     $args = ['post_type'=>'post','posts_per_page'=>intval($a['count'])];
     if($a['location']){
+        $loc = sanitize_title($a['location']);
         $args['tax_query'] = [[
             'taxonomy'=>'uv_location',
             'field'=>'slug',
-            'terms'=>$a['location']
+            'terms'=>$loc
         ]];
     }
     $q = new WP_Query($args);
@@ -176,8 +177,9 @@ function uv_core_activities($atts){
     $a = shortcode_atts(['location'=>'','columns'=>3], $atts);
     $args = ['post_type'=>'uv_activity','posts_per_page'=>-1];
     if($a['location']){
+        $loc = sanitize_title($a['location']);
         $args['tax_query'] = [[
-            'taxonomy'=>'uv_location','field'=>'slug','terms'=>$a['location']
+            'taxonomy'=>'uv_location','field'=>'slug','terms'=>$loc
         ]];
     }
     $q = new WP_Query($args);
@@ -203,11 +205,13 @@ function uv_core_partners($atts){
     $a = shortcode_atts(['location'=>'','type'=>'','columns'=>4], $atts);
     $args = ['post_type'=>'uv_partner','posts_per_page'=>-1];
     $taxq = [];
-    if($a['location']){
-        $taxq[] = ['taxonomy'=>'uv_location','field'=>'slug','terms'=>$a['location']];
+    $loc = $a['location'] ? sanitize_title($a['location']) : '';
+    $type = $a['type'] ? sanitize_title($a['type']) : '';
+    if($loc){
+        $taxq[] = ['taxonomy'=>'uv_location','field'=>'slug','terms'=>$loc];
     }
-    if($a['type']){
-        $taxq[] = ['taxonomy'=>'uv_partner_type','field'=>'slug','terms'=>$a['type']];
+    if($type){
+        $taxq[] = ['taxonomy'=>'uv_partner_type','field'=>'slug','terms'=>$type];
     }
     if($taxq) $args['tax_query'] = $taxq;
     $q = new WP_Query($args);

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -269,7 +269,8 @@ function uv_people_team_grid($atts){
     wp_enqueue_style('uv-team-grid-style');
     $a = shortcode_atts(['location'=>'','columns'=>4,'highlight_primary'=>1], $atts);
     if(!$a['location']) return '';
-    $term = get_term_by('slug', $a['location'], 'uv_location');
+    $loc = sanitize_title($a['location']);
+    $term = get_term_by('slug', $loc, 'uv_location');
     if(!$term) return '';
     $q = new WP_Query([
         'post_type'=>'uv_team_assignment',


### PR DESCRIPTION
## Summary
- Sanitize `location` and `type` attributes in UV Core shortcodes before building taxonomy queries
- Sanitize `location` attribute in UV People team grid shortcode

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d64a4c48328a7687229f8def628