### PR TITLE
Use useBlockProps in block edit components

### DIFF
--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -2,7 +2,7 @@
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-    const { InspectorControls } = wp.blockEditor;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
 
@@ -15,7 +15,7 @@
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];
-            return [
+            return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
                         createElement( SelectControl, {
@@ -33,8 +33,8 @@
                         } )
                     )
                 ),
-                createElement( 'p', {}, __( 'Activities', 'uv-core' ) )
-            ];
+                createElement( 'div', useBlockProps(), __( 'Activities', 'uv-core' ) )
+            );
         },
         save: function() { return null; }
     } );

--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -2,13 +2,13 @@
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-    const { InspectorControls } = wp.blockEditor;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, RangeControl, ToggleControl } = wp.components;
 
     registerBlockType( 'uv/locations-grid', {
         edit: function( props ) {
             const { attributes: { columns, show_links }, setAttributes } = props;
-            return [
+            return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
                         createElement( RangeControl, {
@@ -25,8 +25,8 @@
                         } )
                     )
                 ),
-                createElement( 'p', {}, __( 'Locations Grid', 'uv-core' ) )
-            ];
+                createElement( 'div', useBlockProps(), __( 'Locations Grid', 'uv-core' ) )
+            );
         },
         save: function() { return null; }
     } );

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -2,7 +2,7 @@
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-    const { InspectorControls } = wp.blockEditor;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
 
@@ -15,7 +15,7 @@
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];
-            return [
+            return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
                         createElement( SelectControl, {
@@ -33,8 +33,8 @@
                         } )
                     )
                 ),
-                createElement( 'p', {}, __( 'News', 'uv-core' ) )
-            ];
+                createElement( 'div', useBlockProps(), __( 'News', 'uv-core' ) )
+            );
         },
         save: function() { return null; }
     } );

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -2,7 +2,7 @@
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-    const { InspectorControls } = wp.blockEditor;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
 
@@ -17,7 +17,7 @@
             }, [] );
             const locationOptions = locations ? locations.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
             const typeOptions = types ? types.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
-            return [
+            return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
                         createElement( SelectControl, {
@@ -41,8 +41,8 @@
                         } )
                     )
                 ),
-                createElement( 'p', {}, __( 'Partners', 'uv-core' ) )
-            ];
+                createElement( 'div', useBlockProps(), __( 'Partners', 'uv-core' ) )
+            );
         },
         save: function() { return null; }
     } );

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -2,7 +2,7 @@
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-    const { InspectorControls } = wp.blockEditor;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
 
@@ -15,7 +15,7 @@
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];
-            return [
+            return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-people' ), initialOpen: true },
                         createElement( SelectControl, {
@@ -33,8 +33,8 @@
                         } )
                     )
                 ),
-                createElement( 'p', {}, __( 'Team Grid', 'uv-people' ) )
-            ];
+                createElement( 'div', useBlockProps(), __( 'Team Grid', 'uv-people' ) )
+            );
         },
         save: function() {
             return null;


### PR DESCRIPTION
## Summary
- import and apply `useBlockProps` across Activities, Locations Grid, News, Partners, and Team Grid blocks
- return fragments with a div root so blocks can receive focus and inspector settings

## Testing
- `node --check plugins/uv-core/blocks/*/index.js plugins/uv-people/blocks/team-grid/index.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac191192108328acc939aa13c0dd81