### PR TITLE
Use ServerSideRender for dynamic blocks

### DIFF
--- a/plugins/uv-core/blocks/activities/index.asset.php
+++ b/plugins/uv-core/blocks/activities/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -5,6 +5,7 @@
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
+    const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/activities', {
         edit: function( props ) {
@@ -33,7 +34,12 @@
                         } )
                     )
                 ),
-                createElement( 'div', useBlockProps(), __( 'Activities', 'uv-core' ) )
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/activities',
+                        attributes: props.attributes,
+                    } )
+                )
             );
         },
         save: function() { return null; }

--- a/plugins/uv-core/blocks/locations-grid/index.asset.php
+++ b/plugins/uv-core/blocks/locations-grid/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -4,6 +4,7 @@
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, RangeControl, ToggleControl } = wp.components;
+    const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/locations-grid', {
         edit: function( props ) {
@@ -25,7 +26,12 @@
                         } )
                     )
                 ),
-                createElement( 'div', useBlockProps(), __( 'Locations Grid', 'uv-core' ) )
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/locations-grid',
+                        attributes: props.attributes,
+                    } )
+                )
             );
         },
         save: function() { return null; }

--- a/plugins/uv-core/blocks/news/index.asset.php
+++ b/plugins/uv-core/blocks/news/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -5,6 +5,7 @@
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
+    const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/news', {
         edit: function( props ) {
@@ -33,7 +34,12 @@
                         } )
                     )
                 ),
-                createElement( 'div', useBlockProps(), __( 'News', 'uv-core' ) )
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/news',
+                        attributes: props.attributes,
+                    } )
+                )
             );
         },
         save: function() { return null; }

--- a/plugins/uv-core/blocks/partners/index.asset.php
+++ b/plugins/uv-core/blocks/partners/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -5,6 +5,7 @@
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
+    const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/partners', {
         edit: function( props ) {
@@ -41,7 +42,12 @@
                         } )
                     )
                 ),
-                createElement( 'div', useBlockProps(), __( 'Partners', 'uv-core' ) )
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/partners',
+                        attributes: props.attributes,
+                    } )
+                )
             );
         },
         save: function() { return null; }

--- a/plugins/uv-people/blocks/team-grid/index.asset.php
+++ b/plugins/uv-people/blocks/team-grid/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -5,6 +5,7 @@
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
     const { useSelect } = wp.data;
+    const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/team-grid', {
         edit: function( props ) {
@@ -33,7 +34,12 @@
                         } )
                     )
                 ),
-                createElement( 'div', useBlockProps(), __( 'Team Grid', 'uv-people' ) )
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/team-grid',
+                        attributes: props.attributes,
+                    } )
+                )
             );
         },
         save: function() {


### PR DESCRIPTION
## Summary
- render `team-grid` block via `ServerSideRender`
- render `locations-grid`, `partners`, `activities`, and `news` blocks via `ServerSideRender`
- add `wp-server-side-render` dependency for all blocks

## Testing
- `node --check plugins/uv-people/blocks/team-grid/index.js && echo "team-grid ok"`
- `node --check plugins/uv-core/blocks/locations-grid/index.js && echo "locations-grid ok"`
- `node --check plugins/uv-core/blocks/partners/index.js && echo "partners ok"`
- `node --check plugins/uv-core/blocks/activities/index.js && echo "activities ok"`
- `node --check plugins/uv-core/blocks/news/index.js && echo "news ok"`
- `php -l plugins/uv-people/blocks/team-grid/index.asset.php`
- `php -l plugins/uv-core/blocks/locations-grid/index.asset.php`
- `php -l plugins/uv-core/blocks/partners/index.asset.php`
- `php -l plugins/uv-core/blocks/activities/index.asset.php`
- `php -l plugins/uv-core/blocks/news/index.asset.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a7ec428832885269ab5fd2a85f0