### PR TITLE
Add Unge Vil block category

### DIFF
--- a/plugins/uv-core/blocks/activities/block.json
+++ b/plugins/uv-core/blocks/activities/block.json
@@ -2,7 +2,7 @@
   "apiVersion": 2,
   "name": "uv/activities",
   "title": "Activities",
-  "category": "widgets",
+  "category": "unge-vil",
   "icon": "admin-site",
   "attributes": {
     "location": {"type": "string", "default": ""},

--- a/plugins/uv-core/blocks/locations-grid/block.json
+++ b/plugins/uv-core/blocks/locations-grid/block.json
@@ -2,7 +2,7 @@
   "apiVersion": 2,
   "name": "uv/locations-grid",
   "title": "Locations Grid",
-  "category": "widgets",
+  "category": "unge-vil",
   "icon": "location-alt",
   "attributes": {
     "columns": {"type": "number", "default": 3},

--- a/plugins/uv-core/blocks/news/block.json
+++ b/plugins/uv-core/blocks/news/block.json
@@ -2,7 +2,7 @@
   "apiVersion": 2,
   "name": "uv/news",
   "title": "News",
-  "category": "widgets",
+  "category": "unge-vil",
   "icon": "megaphone",
   "attributes": {
     "location": {"type": "string", "default": ""},

--- a/plugins/uv-core/blocks/partners/block.json
+++ b/plugins/uv-core/blocks/partners/block.json
@@ -2,7 +2,7 @@
   "apiVersion": 2,
   "name": "uv/partners",
   "title": "Partners",
-  "category": "widgets",
+  "category": "unge-vil",
   "icon": "heart",
   "attributes": {
     "location": {"type": "string", "default": ""},

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -10,6 +10,14 @@
 
 if (!defined('ABSPATH')) exit;
 
+add_filter('block_categories_all', function($categories) {
+    $categories[] = [
+        'slug'  => 'unge-vil',
+        'title' => __('Unge Vil blocks', 'uv-core'),
+    ];
+    return $categories;
+}, 10, 2);
+
 add_action('plugins_loaded', function(){
     load_plugin_textdomain('uv-core', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });

--- a/plugins/uv-people/blocks/team-grid/block.json
+++ b/plugins/uv-people/blocks/team-grid/block.json
@@ -2,7 +2,7 @@
   "apiVersion": 2,
   "name": "uv/team-grid",
   "title": "Team Grid",
-  "category": "widgets",
+  "category": "unge-vil",
   "icon": "groups",
   "attributes": {
     "location": {


### PR DESCRIPTION
## Summary
- register custom `unge-vil` block category in UV Core
- classify core and people blocks under `unge-vil`

## Testing
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bc2013c8328a7c38ec70490d51a