### PR TITLE
Prepare 0.3.0 release for theme and plugins

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -78,7 +78,7 @@ add_action('admin_enqueue_scripts', function($hook){
     $screen = get_current_screen();
     if($screen && $screen->taxonomy === 'uv_location'){
         wp_enqueue_media();
-        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], '0.2.0', true);
+        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], '0.3.0', true);
         wp_localize_script('uv-term-image', 'uvTermImage', [
             'selectImage' => esc_html__('Select Image', 'uv-core'),
         ]);

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -23,6 +23,8 @@ UV Events Bridge connects Locations to The Events Calendar.
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.
 
 ## Changelog
+### 0.3.0
+- Bump to version 0.3.0.
 ### 0.2.0
 - Added location filter option to upcoming events shortcode and improved docs.
 ### 0.1.0

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Events Bridge
  * Description: Adds uv_location taxonomy to The Events Calendar events and provides an upcoming events shortcode.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-events-bridge

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -24,6 +24,8 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.3.0
+- Bump to version 0.3.0.
 ### 0.2.0
 - Added `highlight_primary` option to the team grid and improved assignment handling.
 ### 0.1.0

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-people

--- a/themes/uv-kadence-child/readme.md
+++ b/themes/uv-kadence-child/readme.md
@@ -1,6 +1,8 @@
 Kadence child theme for Unge Vil.
 
 ## Changelog
+### 0.3.0
+- Bump to version 0.3.0.
 ### 0.2.0
 - Updated styles for the refreshed admin color scheme.
 ### 0.1.0

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -2,5 +2,5 @@
  Theme Name: UV Kadence Child
  Template: kadence
  Text Domain: uv-kadence-child
- Version: 0.2.0
+ Version: 0.3.0
 */


### PR DESCRIPTION
## Summary
- bump UV Kadence Child theme to 0.3.0 and add changelog entry
- update UV People and UV Events Bridge plugins to 0.3.0 with changelog notes
- sync UV Core term-image script version to 0.3.0

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `php -l plugins/uv-events-bridge/uv-events-bridge.php`
- `php -l plugins/uv-core/uv-core.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ee031f483288007d57f378c7a26