### PR TITLE
Add GitHub update checkers

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -6,9 +6,24 @@
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-core
+ * Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/plugins/uv-core
  */
 
 if (!defined('ABSPATH')) exit;
+
+$update_checker_path = __DIR__ . '/../../lib/plugin-update-checker/plugin-update-checker.php';
+if (file_exists($update_checker_path)) {
+    require $update_checker_path;
+    $uvCoreUpdateChecker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpdateChecker(
+        'https://github.com/Unge-Vil/Unge-Vil-Website/',
+        __FILE__,
+        'uv-core'
+    );
+    $uvCoreUpdateChecker->setBranch('main');
+    if (method_exists($uvCoreUpdateChecker, 'setPathInsideRepository')) {
+        $uvCoreUpdateChecker->setPathInsideRepository('plugins/uv-core');
+    }
+}
 
 add_filter('block_categories_all', function($categories) {
     $categories[] = [

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -6,8 +6,23 @@
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-events-bridge
+ * Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/plugins/uv-events-bridge
  */
 if (!defined('ABSPATH')) exit;
+
+$update_checker_path = __DIR__ . '/../../lib/plugin-update-checker/plugin-update-checker.php';
+if (file_exists($update_checker_path)) {
+    require $update_checker_path;
+    $uvEventsBridgeUpdateChecker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpdateChecker(
+        'https://github.com/Unge-Vil/Unge-Vil-Website/',
+        __FILE__,
+        'uv-events-bridge'
+    );
+    $uvEventsBridgeUpdateChecker->setBranch('main');
+    if (method_exists($uvEventsBridgeUpdateChecker, 'setPathInsideRepository')) {
+        $uvEventsBridgeUpdateChecker->setPathInsideRepository('plugins/uv-events-bridge');
+    }
+}
 
 add_action('init', function(){
     if(post_type_exists('tribe_events')){

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -6,8 +6,23 @@
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-people
+ * Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/plugins/uv-people
  */
 if (!defined('ABSPATH')) exit;
+
+$update_checker_path = __DIR__ . '/../../lib/plugin-update-checker/plugin-update-checker.php';
+if (file_exists($update_checker_path)) {
+    require $update_checker_path;
+    $uvPeopleUpdateChecker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpdateChecker(
+        'https://github.com/Unge-Vil/Unge-Vil-Website/',
+        __FILE__,
+        'uv-people'
+    );
+    $uvPeopleUpdateChecker->setBranch('main');
+    if (method_exists($uvPeopleUpdateChecker, 'setPathInsideRepository')) {
+        $uvPeopleUpdateChecker->setPathInsideRepository('plugins/uv-people');
+    }
+}
 
 // Load textdomain
 add_action('plugins_loaded', function(){

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -2,6 +2,20 @@
 /**
  * UV Kadence Child theme functions
  */
+$update_checker_path = __DIR__ . '/../../lib/plugin-update-checker/plugin-update-checker.php';
+if (file_exists($update_checker_path)) {
+    require $update_checker_path;
+    $uvThemeUpdateChecker = \YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpdateChecker(
+        'https://github.com/Unge-Vil/Unge-Vil-Website/',
+        __FILE__,
+        'uv-kadence-child',
+        'theme'
+    );
+    $uvThemeUpdateChecker->setBranch('main');
+    if (method_exists($uvThemeUpdateChecker, 'setPathInsideRepository')) {
+        $uvThemeUpdateChecker->setPathInsideRepository('themes/uv-kadence-child');
+    }
+}
 add_action('wp_enqueue_scripts', function() {
     wp_enqueue_style('uv-child', get_stylesheet_uri(), [], wp_get_theme()->get('Version'));
 

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -3,4 +3,5 @@
  Template: kadence
  Text Domain: uv-kadence-child
  Version: 0.3.0
+ Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/themes/uv-kadence-child
 */


### PR DESCRIPTION
## Summary
- enable automatic GitHub-based updates for UV Core, People, Events Bridge plugins and UV Kadence Child theme
- advertise repository Update URI headers for WordPress core update checks

## Testing
- `php -l plugins/uv-core/uv-core.php && php -l plugins/uv-people/uv-people.php && php -l plugins/uv-events-bridge/uv-events-bridge.php && php -l themes/uv-kadence-child/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac23f42ddc8328b48b618b273d61bf