### PR TITLE
docs: refresh executive summary and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary (Plain Language)
 - **Goal by Sept 1:** Launch a fast, accessible site with Home, core info pages, and location-based **Team pages** (primary contacts highlighted). Norwegian first; English ready.
-- **Later (phase 2+):** Activities, Events, Partners, Experiences, deeper translations.
+- **v0.4.0:** Activities, Events bridge, Partners, Experiences live. Still to do: deeper translations, automation, etc.
 - **Admin:** Clean, branded Control Panel in English; link to our Google Workspace docs.
 - **Accessibility & SEO:** Built-in best practices; editors add alt text and clear headings.
 - **Future-proof:** Small, readable plugins; easy to extend. Volunteers welcome — this is largely vibe-coded with help from ChatGPT, so expert contributors are invited!
@@ -10,6 +10,10 @@
 
 This repository bootstraps the **Kadence child theme** and three lightweight plugins for the Unge Vil website.
 It’s designed for **shared hosting**, with a focus on **accessibility, performance, and translation readiness**.
+
+## Roadmap
+- **v0.5.0:** Deeper translation coverage and basic automation for packaging and releases.
+- **v1.0.0:** Fully bilingual content with streamlined deployment and contributor workflows.
 
 ## Contents
 - `themes/uv-kadence-child/` – Kadence child theme (styles, small a11y tweaks).


### PR DESCRIPTION
## Summary
- update executive summary with v0.4.0 features and remaining work
- add roadmap section highlighting upcoming milestones

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac27803d3c8328bd21b3d2dd818cdc