### PR TITLE
docs: clarify Locations guidance for posts

### DIFF
--- a/docs/EDITOR-GUIDE.md
+++ b/docs/EDITOR-GUIDE.md
@@ -27,5 +27,5 @@ Simple steps for managing common content types in the WordPress dashboard.
 ## News / Blog Posts
 1. Go to **Posts → Add New**.
 2. Write the title, content, and set a featured image if desired.
-3. In the **Categories** panel, choose the category that matches the location name (add a new category if required).
+3. In the **Locations** taxonomy box, select the Location that matches the location name (create a new Location term if needed).
 4. Publish the post.


### PR DESCRIPTION
## Summary
- adjust editor instructions to use the Locations taxonomy instead of Categories for news/blog posts
- note that new Location terms can be created if needed

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac278d972c83288b317594e2d867a8