### PR TITLE
docs: update later-phase tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary (Plain Language)
 - **Goal by Sept 1:** Launch a fast, accessible site with Home, core info pages, and location-based **Team pages** (primary contacts highlighted). Norwegian first; English ready.
-- **Later (phase 2+):** Activities, Events, Partners, Experiences, deeper translations.
+- **Later (phase 2+):** Partner directory, deeper translations, more automation/import tools.
 - **Admin:** Clean, branded Control Panel in English; link to our Google Workspace docs.
 - **Accessibility & SEO:** Built-in best practices; editors add alt text and clear headings.
 - **Future-proof:** Small, readable plugins; easy to extend. Volunteers welcome — this is largely vibe-coded with help from ChatGPT, so expert contributors are invited!

--- a/docs/BOARD-SUMMARY.md
+++ b/docs/BOARD-SUMMARY.md
@@ -7,9 +7,7 @@
 - English-ready (we start in Norwegian but can translate later)
 
 **Later phases (after launch):**
-- Activities catalog
-- Events calendar
-- Competency/Experiences
+- Partner directory
 - Advanced translations for content
 - More automation/import tools
 

--- a/docs/CONTENT-SPRINT.md
+++ b/docs/CONTENT-SPRINT.md
@@ -24,4 +24,4 @@
 - SEO pass (titles, slugs, meta; internal links).
 - Set up sitemaps in SEO plugin; submit to Google Search Console.
 
-*Optional after launch: Activities, Events, Partners, Experiences.*
+*Optional after launch: Partner directory, English translations, automation/import tools.*


### PR DESCRIPTION
## Summary
- Remove completed features from later phase list and add partner directory milestone
- Sync README and content sprint guide with new after-launch plans

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac278832308328ab375a58730bdb0d