### PR TITLE
docs: describe experience team members meta box

### DIFF
--- a/docs/EXPERIENCES.md
+++ b/docs/EXPERIENCES.md
@@ -10,4 +10,4 @@
 When editing an Experience, use the **Related Post** meta box in the sidebar to choose an existing blog post. Select **— None —** if no blog post should be connected.
 
 ## Linking to a WordPress User
-Experiences do not include a dedicated user selector. If needed, you can store a user reference in a custom field or mention the user in the content. Team visibility is managed separately through User → Location assignments.
+Use the **Team Members** meta box (`uv_experience_users`) to associate one or more WordPress users with an Experience. Start typing in the selector to search and choose people; multiple users can be selected. On the front end, the selected users appear beneath the Experience content with their profile details. Team visibility is managed separately through User → Location assignments.


### PR DESCRIPTION
## Summary
- document Team Members meta box (`uv_experience_users`) for Experiences
- remove obsolete custom-field advice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac279ad97c832899e0a8a6fe37f15d