### PR TITLE
Bump theme and plugins to 0.4.0

### DIFF
--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -34,6 +34,8 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.
 
 ## Changelog
+### 0.4.0
+- Bump to version 0.4.0.
 ### 0.3.0
 - Added partner display meta field with logo and title layout options.
 ### 0.2.0

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Core
  * Description: CPTs, taxonomies, term images, and lightweight shortcodes.
- * Version: 0.3.0
+ * Version: 0.4.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-core
@@ -93,7 +93,7 @@ add_action('admin_enqueue_scripts', function($hook){
     $screen = get_current_screen();
     if($screen && $screen->taxonomy === 'uv_location'){
         wp_enqueue_media();
-        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], '0.3.0', true);
+        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], '0.4.0', true);
         wp_localize_script('uv-term-image', 'uvTermImage', [
             'selectImage' => esc_html__('Select Image', 'uv-core'),
         ]);

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -23,6 +23,8 @@ UV Events Bridge connects Locations to The Events Calendar.
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.
 
 ## Changelog
+### 0.4.0
+- Bump to version 0.4.0.
 ### 0.3.0
 - Bump to version 0.3.0.
 ### 0.2.0

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Events Bridge
  * Description: Adds uv_location taxonomy to The Events Calendar events and provides an upcoming events shortcode.
- * Version: 0.3.0
+ * Version: 0.4.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-events-bridge

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -24,6 +24,8 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.4.0
+- Bump to version 0.4.0.
 ### 0.3.0
 - Bump to version 0.3.0.
 ### 0.2.0

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
- * Version: 0.3.0
+ * Version: 0.4.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: uv-people

--- a/themes/uv-kadence-child/readme.md
+++ b/themes/uv-kadence-child/readme.md
@@ -1,6 +1,8 @@
 Kadence child theme for Unge Vil.
 
 ## Changelog
+### 0.4.0
+- Bump to version 0.4.0.
 ### 0.3.0
 - Bump to version 0.3.0.
 ### 0.2.0

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -2,6 +2,6 @@
  Theme Name: UV Kadence Child
  Template: kadence
  Text Domain: uv-kadence-child
- Version: 0.3.0
+ Version: 0.4.0
  Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/themes/uv-kadence-child
 */


### PR DESCRIPTION
## Summary
- bump child theme and plugins to version 0.4.0
- update term-image script version in uv-core
- add 0.4.0 sections to changelogs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`
- `php -l plugins/uv-events-bridge/uv-events-bridge.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac277504d88328ad39b9513adc9654