### PR TITLE
Load Kadence styles for control panel

### DIFF
--- a/themes/uv-kadence-child/assets/css/control-panel.css
+++ b/themes/uv-kadence-child/assets/css/control-panel.css
@@ -1,0 +1,6 @@
+/*
+ * Admin Control Panel styles.
+ * Ensures Kadence blocks display correctly in the admin control panel.
+ */
+
+/* Add custom styles for the control panel here if needed. */

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -103,6 +103,43 @@ add_filter('login_redirect', function($redirect_to, $request, $user) {
     return $redirect_to;
 }, 10, 3);
 
+// Enqueue styles for the Control Panel admin page
+add_action('admin_enqueue_scripts', function($hook) {
+    if ('toplevel_page_uv-control-panel' !== $hook) {
+        return;
+    }
+
+    $deps = [];
+
+    // Parent Kadence theme stylesheet
+    wp_enqueue_style(
+        'kadence-theme',
+        get_template_directory_uri() . '/style.css',
+        [],
+        wp_get_theme()->get('Version')
+    );
+    $deps[] = 'kadence-theme';
+
+    // Kadence Blocks global stylesheet, if plugin is active
+    if (defined('KADENCE_BLOCKS_VERSION') && defined('KADENCE_BLOCKS_MAIN_FILE')) {
+        wp_enqueue_style(
+            'kadence-blocks',
+            plugins_url('dist/blocks.style.build.css', KADENCE_BLOCKS_MAIN_FILE),
+            ['kadence-theme'],
+            KADENCE_BLOCKS_VERSION
+        );
+        $deps[] = 'kadence-blocks';
+    }
+
+    // Control Panel specific styles
+    wp_enqueue_style(
+        'uv-control-panel',
+        get_stylesheet_directory_uri() . '/assets/css/control-panel.css',
+        $deps,
+        wp_get_theme()->get('Version')
+    );
+});
+
 /**
  * Render the Control Panel admin page.
  */


### PR DESCRIPTION
## Summary
- enqueue Kadence theme stylesheet on the Control Panel admin page
- include Kadence Blocks global styles when the plugin is active
- load custom Control Panel stylesheet depending on Kadence assets

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac39b4217c8328833be7042799b8e6