### PR TITLE
Use apiFetch for taxonomy terms in block editors

### DIFF
--- a/plugins/uv-core/blocks/activities/index.asset.php
+++ b/plugins/uv-core/blocks/activities/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -1,21 +1,22 @@
 ( function( wp ) {
-    const { createElement } = wp.element;
+    const { createElement, useEffect, useState } = wp.element;
+    const apiFetch = wp.apiFetch;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
-    const { useSelect } = wp.data;
     const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/activities', {
         edit: function( props ) {
             const { attributes: { location, columns }, setAttributes } = props;
-            const terms = useSelect( function( select ) {
-                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            const [ terms, setTerms ] = useState( [] );
+            useEffect( function() {
+                apiFetch( { path: '/wp/v2/uv_location?per_page=-1' } ).then( setTerms );
             }, [] );
-            const options = terms ? terms.map( function( t ) {
+            const options = terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
-            } ) : [];
+            } );
             return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },

--- a/plugins/uv-core/blocks/news/index.asset.php
+++ b/plugins/uv-core/blocks/news/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -1,21 +1,22 @@
 ( function( wp ) {
-    const { createElement } = wp.element;
+    const { createElement, useEffect, useState } = wp.element;
+    const apiFetch = wp.apiFetch;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
-    const { useSelect } = wp.data;
     const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/news', {
         edit: function( props ) {
             const { attributes: { location, count }, setAttributes } = props;
-            const terms = useSelect( function( select ) {
-                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            const [ terms, setTerms ] = useState( [] );
+            useEffect( function() {
+                apiFetch( { path: '/wp/v2/uv_location?per_page=-1' } ).then( setTerms );
             }, [] );
-            const options = terms ? terms.map( function( t ) {
+            const options = terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
-            } ) : [];
+            } );
             return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },

--- a/plugins/uv-core/blocks/partners/index.asset.php
+++ b/plugins/uv-core/blocks/partners/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -1,23 +1,23 @@
 ( function( wp ) {
-    const { createElement } = wp.element;
+    const { createElement, useEffect, useState } = wp.element;
+    const apiFetch = wp.apiFetch;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
-    const { useSelect } = wp.data;
     const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/partners', {
         edit: function( props ) {
             const { attributes: { location, type, columns }, setAttributes } = props;
-            const locations = useSelect( function( select ) {
-                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            const [ locations, setLocations ] = useState( [] );
+            const [ types, setTypes ] = useState( [] );
+            useEffect( function() {
+                apiFetch( { path: '/wp/v2/uv_location?per_page=-1' } ).then( setLocations );
+                apiFetch( { path: '/wp/v2/uv_partner_type?per_page=-1' } ).then( setTypes );
             }, [] );
-            const types = useSelect( function( select ) {
-                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_partner_type', { per_page: -1 } );
-            }, [] );
-            const locationOptions = locations ? locations.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
-            const typeOptions = types ? types.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
+            const locationOptions = locations.map( function( t ) { return { label: t.name, value: t.slug }; } );
+            const typeOptions = types.map( function( t ) { return { label: t.name, value: t.slug }; } );
             return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },

--- a/plugins/uv-people/blocks/team-grid/index.asset.php
+++ b/plugins/uv-people/blocks/team-grid/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -1,21 +1,22 @@
 ( function( wp ) {
-    const { createElement } = wp.element;
+    const { createElement, useEffect, useState } = wp.element;
+    const apiFetch = wp.apiFetch;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
     const { PanelBody, SelectControl, RangeControl } = wp.components;
-    const { useSelect } = wp.data;
     const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/team-grid', {
         edit: function( props ) {
             const { attributes: { location, columns }, setAttributes } = props;
-            const terms = useSelect( function( select ) {
-                return select( 'core' ).getEntityRecords( 'taxonomy', 'uv_location', { per_page: -1 } );
+            const [ terms, setTerms ] = useState( [] );
+            useEffect( function() {
+                apiFetch( { path: '/wp/v2/uv_location?per_page=-1' } ).then( setTerms );
             }, [] );
-            const options = terms ? terms.map( function( t ) {
+            const options = terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
-            } ) : [];
+            } );
             return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-people' ), initialOpen: true },


### PR DESCRIPTION
## Summary
- Replace `useSelect` with `apiFetch` to load taxonomy terms in activities, news, partners, and team-grid blocks
- Store fetched terms in `useState` via `useEffect` so UI updates after loading
- Update block asset dependencies to include `wp-api-fetch`

## Testing
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3aca9ec483288f51ca54bb60a153