### PR TITLE
Adjust uv_people_profile_fields hook priority

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -211,8 +211,8 @@ function uv_people_profile_fields($user){
     </table>
     <?php
 }
-add_action('show_user_profile','uv_people_profile_fields');
-add_action('edit_user_profile','uv_people_profile_fields');
+add_action('show_user_profile','uv_people_profile_fields',5);
+add_action('edit_user_profile','uv_people_profile_fields',5);
 
 add_action('personal_options_update','uv_people_profile_save');
 add_action('edit_user_profile_update','uv_people_profile_save');


### PR DESCRIPTION
## Summary
- ensure custom user profile fields render before core contact fields by hooking at priority 5

## Testing
- `npm test` *(fails: missing package.json)*
- `composer test` *(fails: Command "test" is not defined.)*
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac3eba3e30832888ed36b3abd4f561