### PR TITLE
Prepend block category

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -28,10 +28,10 @@ if (file_exists($update_checker_path)) {
 }
 
 add_filter('block_categories_all', function($categories) {
-    $categories[] = [
+    array_unshift($categories, [
         'slug'  => 'unge-vil',
         'title' => __('Unge Vil blocks', 'uv-core'),
-    ];
+    ]);
     return $categories;
 }, 10, 2);
 


### PR DESCRIPTION
## Summary
- Prepend "Unge Vil blocks" category in block editor using `array_unshift`

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac41e06cd08328bfbee855b508f305