### PR TITLE
style: unify person cards and responsive grid

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -1,16 +1,19 @@
 .uv-team-grid {
     display: grid;
     gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 .uv-team-grid .uv-person {
     display: flex;
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: center;
     gap: 1rem;
     text-decoration: none;
+    height: 100%;
 }
 .uv-team-grid .uv-avatar img {
     border-radius: 12px;
-    max-width: 128px;
+    width: 100%;
     height: auto;
 }
 .uv-team-grid .uv-info > *:empty {

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -8,12 +8,9 @@
 .uv-card .uv-card-body{padding:12px}
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{outline:3px solid var(--uv-purple)}
-.uv-team-grid{display:grid;gap:1rem}
-@media(min-width:768px){.uv-team-grid{grid-template-columns:repeat(3,1fr)}}
-@media(min-width:1024px){.uv-team-grid{grid-template-columns:repeat(4,1fr)}}
-.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem}
-.uv-person h3{margin:.3rem 0 0;font-size:1.1rem}
-.uv-person .uv-role{font-size:.95rem;color:#555}
+.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;gap:.5rem;height:100%}
+.uv-person h3{margin:.3rem 0 0;font-size:1.1rem;color:var(--uv-purple)}
+.uv-person .uv-role{font-size:.95rem;color:#555;margin-top:.2rem}
 .uv-person .uv-quote{margin:.5rem 0 0;padding:0;font-style:italic;color:#333}
 .uv-card-body h3{margin:0;font-size:1rem}
 


### PR DESCRIPTION
## Summary
- standardize `.uv-person` cards with flex layout, purple headings, and spacing
- implement responsive team grid columns and scalable avatar images

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac535876b083288ea359efb51aad9c