### PR TITLE
Add default size to locations grid ToggleControl

### DIFF
--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -25,6 +25,7 @@
                             label: __( 'Show Links', 'uv-core' ),
                             checked: show_links,
                             onChange: function( value ) { setAttributes( { show_links: value } ); },
+                            __next40pxDefaultSize: true,
                             __nextHasNoMarginBottom: true
                         } )
                     )


### PR DESCRIPTION
## Summary
- add `__next40pxDefaultSize` to locations-grid toggle block control
- searched for deprecated `wp.editPost` PluginSidebar references (none found)

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5496615883289feeb514b437a4fa