### PR TITLE
Bump UV People to 0.5.0

### DIFF
--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-people 0.1.0\n"
+"Project-Id-Version: uv-people 0.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-21 08:36+0000\n"
+"POT-Creation-Date: 2025-08-25 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -24,6 +24,8 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.5.0
+- Bump to version 0.5.0.
 ### 0.4.1
 - Minor bug fixes.
 ### 0.4.0

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
- * Version: 0.4.1
+ * Version: 0.5.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil
@@ -41,7 +41,7 @@ add_action('admin_enqueue_scripts', function($hook){
             'uv-people-admin',
             plugin_dir_url(__FILE__) . 'assets/admin.js',
             ['jquery', 'select2'],
-            '0.1',
+            '0.5.0',
             true
         );
         wp_localize_script('uv-people-admin', 'UVPeople', [


### PR DESCRIPTION
## Summary
- bump UV People plugin version to 0.5.0
- align admin.js enqueue version
- update changelog and translation metadata

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `composer test` (fails: Command "test" is not defined.)
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ac574b0af083289f7b132d35eed7d8