### PR TITLE
Replace deprecated block editor options

### DIFF
--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -25,8 +25,7 @@
                             value: location,
                             options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( options ),
                             onChange: function( value ) { setAttributes( { location: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( RangeControl, {
                             label: __( 'Columns', 'uv-core' ),
@@ -34,8 +33,7 @@
                             max: 6,
                             value: columns,
                             onChange: function( value ) { setAttributes( { columns: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } )
                     )
                 ),

--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -18,15 +18,13 @@
                             max: 6,
                             value: columns,
                             onChange: function( value ) { setAttributes( { columns: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( ToggleControl, {
                             label: __( 'Show Links', 'uv-core' ),
                             checked: show_links,
                             onChange: function( value ) { setAttributes( { show_links: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } )
                     )
                 ),

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -25,8 +25,7 @@
                             value: location,
                             options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( options ),
                             onChange: function( value ) { setAttributes( { location: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( RangeControl, {
                             label: __( 'Count', 'uv-core' ),
@@ -34,8 +33,7 @@
                             max: 10,
                             value: count,
                             onChange: function( value ) { setAttributes( { count: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } )
                     )
                 ),

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -26,16 +26,14 @@
                             value: location,
                             options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( locationOptions ),
                             onChange: function( value ) { setAttributes( { location: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( SelectControl, {
                             label: __( 'Type', 'uv-core' ),
                             value: type,
                             options: [ { label: __( 'Select', 'uv-core' ), value: '' } ].concat( typeOptions ),
                             onChange: function( value ) { setAttributes( { type: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( RangeControl, {
                             label: __( 'Columns', 'uv-core' ),
@@ -43,8 +41,7 @@
                             max: 6,
                             value: columns,
                             onChange: function( value ) { setAttributes( { columns: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } )
                     )
                 ),

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -25,8 +25,7 @@
                             value: location,
                             options: [ { label: __( 'Select', 'uv-people' ), value: '' } ].concat( options ),
                             onChange: function( value ) { setAttributes( { location: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } ),
                         createElement( RangeControl, {
                             label: __( 'Columns', 'uv-people' ),
@@ -34,8 +33,7 @@
                             max: 6,
                             value: columns,
                             onChange: function( value ) { setAttributes( { columns: value } ); },
-                            __next40pxDefaultSize: true,
-                            __nextHasNoMarginBottom: true
+                            style: { height: '40px', marginBottom: 0 }
                         } )
                     )
                 ),


### PR DESCRIPTION
## Summary
- remove `__next40pxDefaultSize` and `__nextHasNoMarginBottom` from uv-core and uv-people block controls
- use stable `style` props for consistent height and no margin bottom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58bcdecc8328889defc35df66734