### PR TITLE
docs: update version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,19 @@ While deploying or migrating, enable **Maintenance** plugin (already installed),
 - Add your how-to videos/links in **Dashboard → Team Guide** widget (config in `uv-people`).
 
 ## Building ZIPs from GitHub
-Tag a release like `v0.1.0` and GitHub Actions will attach zips for the child theme and each plugin.
+Tag a release like `v0.5.0` and GitHub Actions will attach zips for the child theme and each plugin.
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
 See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
 ### Tagging and making releases
 1. Commit your changes and push them to GitHub.
 2. In the repository, click **Releases** → **Draft a new release**.
-3. In **Tag version**, enter a new tag like `v0.1.1` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
+3. In **Tag version**, enter a new tag like `v0.5.1` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
 4. Choose **Create new tag on publish**, leaving the target branch as `main`.
 5. Add a title and notes, then click **Publish release**. GitHub Actions will build ZIPs for the theme and each plugin and attach them to the release.
 6. After the workflow completes, download the ZIPs from the release page and upload them to WordPress to update.
 
-> To tag from the command line instead, run `git tag v0.1.1 && git push origin v0.1.1` before drafting the release.
+> To tag from the command line instead, run `git tag v0.5.1 && git push origin v0.5.1` before drafting the release.
 
 ---
 © 2025 Unge Vil. MIT License.

--- a/docs/MIGRATION-UV-PEOPLE-LEGACY-META.md
+++ b/docs/MIGRATION-UV-PEOPLE-LEGACY-META.md
@@ -1,6 +1,6 @@
 # Migration: Remove legacy people meta
 
-The `uv-people` plugin now relies solely on the translated meta keys `uv_role_nb`, `uv_role_en`, `uv_quote_nb`, and `uv_quote_en`.
+As of `uv-people` **v0.5.0**, the plugin relies solely on the translated meta keys `uv_role_nb`, `uv_role_en`, `uv_quote_nb`, and `uv_quote_en`.
 Legacy fields `uv_role_title` and `uv_quote` are no longer read when rendering team members.
 
 To migrate existing data run the bundled WP‑CLI command:
@@ -10,4 +10,4 @@ wp uv-people migrate-legacy-meta
 ```
 
 The command copies old values into the new translated fields and deletes the legacy keys.
-Run it once after updating the plugin.
+Run it once after updating to `uv-people` v0.5.0 or later.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -2,7 +2,7 @@
 
 ## 1. Get the new ZIPs
 1. Visit the repository's [Releases](https://github.com/ungevil/Unge-Vil-Website/releases) page.
-2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`).
+2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `v0.5.0`).
 
 ## 2. Back up the site
 1. In your hosting panel or backup plugin (e.g. UpdraftPlus), run a full backup.
@@ -21,6 +21,6 @@
 3. Click **Install Now**, choose **Replace current version** when asked, then **Activate**.
 
 ## 4. Verify versions
-1. In **Plugins**, confirm each plugin lists the new version number.
+1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.5.0`).
 2. In **Appearance → Themes**, open the child theme details and verify its version.
 3. Browse a few pages on the front‑end to confirm the site loads as expected.


### PR DESCRIPTION
## Summary
- clarify that theme and plugin releases are retrieved per latest tag (e.g. v0.5.0)
- update release instructions to tag examples v0.5.0 and v0.5.1
- note that uv-people v0.5.0 removes legacy meta keys and requires migration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58bc4ea48328b4d65e8ceaf3c9b3