### PR TITLE
feat: add shared term fetch helper

### DIFF
--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -1,6 +1,7 @@
+import fetchTerms from '../utils/fetchTerms';
+
 ( function( wp ) {
     const { createElement } = wp.element;
-    const { useSelect } = wp.data;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
@@ -11,13 +12,7 @@
         edit: function( props ) {
             const { attributes: { location, columns }, setAttributes } = props;
             const query = { per_page: 100 };
-            const { terms, error } = useSelect( function( select ) {
-                const core = select( 'core' );
-                return {
-                    terms: core.getEntityRecords( 'taxonomy', 'uv_location', query ),
-                    error: core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', 'uv_location', query ) : null
-                };
-            }, [] );
+            const { terms, error } = fetchTerms( 'uv_location', query );
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -1,6 +1,7 @@
+import fetchTerms from '../utils/fetchTerms';
+
 ( function( wp ) {
     const { createElement } = wp.element;
-    const { useSelect } = wp.data;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
@@ -11,13 +12,7 @@
         edit: function( props ) {
             const { attributes: { location, count }, setAttributes } = props;
             const query = { per_page: 100 };
-            const { terms, error } = useSelect( function( select ) {
-                const core = select( 'core' );
-                return {
-                    terms: core.getEntityRecords( 'taxonomy', 'uv_location', query ),
-                    error: core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', 'uv_location', query ) : null
-                };
-            }, [] );
+            const { terms, error } = fetchTerms( 'uv_location', query );
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -1,6 +1,7 @@
+import fetchTerms from '../utils/fetchTerms';
+
 ( function( wp ) {
     const { createElement } = wp.element;
-    const { useSelect } = wp.data;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
@@ -11,20 +12,12 @@
         edit: function( props ) {
             const { attributes: { location, type, columns }, setAttributes } = props;
             const query = { per_page: 100 };
-            const {
-                locations,
-                types,
-                locationError,
-                typeError
-            } = useSelect( function( select ) {
-                const core = select( 'core' );
-                return {
-                    locations: core.getEntityRecords( 'taxonomy', 'uv_location', query ),
-                    types: core.getEntityRecords( 'taxonomy', 'uv_partner_type', query ),
-                    locationError: core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', 'uv_location', query ) : null,
-                    typeError: core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', 'uv_partner_type', query ) : null
-                };
-            }, [] );
+            const locationData = fetchTerms( 'uv_location', query );
+            const typeData = fetchTerms( 'uv_partner_type', query );
+            const locations = locationData.terms;
+            const types = typeData.terms;
+            const locationError = locationData.error;
+            const typeError = typeData.error;
             const locationOptions = locations ? locations.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
             const typeOptions = types ? types.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
             return createElement( wp.element.Fragment, {},

--- a/plugins/uv-core/blocks/utils/fetchTerms.js
+++ b/plugins/uv-core/blocks/utils/fetchTerms.js
@@ -1,0 +1,24 @@
+const { useSelect } = wp.data;
+const cache = {};
+
+/**
+ * Fetch taxonomy terms with basic caching.
+ *
+ * @param {string} taxonomy Taxonomy name.
+ * @param {Object} query     Optional query args.
+ * @returns {Object}         Object with terms and error.
+ */
+export default function fetchTerms( taxonomy, query ) {
+    query = query || { per_page: 100 };
+    const cacheKey = taxonomy + JSON.stringify( query );
+    return useSelect( function( select ) {
+        const core = select( 'core' );
+        const terms = core.getEntityRecords( 'taxonomy', taxonomy, query );
+        const error = core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', taxonomy, query ) : null;
+        const result = { terms, error };
+        if ( terms ) {
+            cache[ cacheKey ] = result;
+        }
+        return cache[ cacheKey ] || result;
+    }, [] );
+}

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -1,6 +1,7 @@
+import fetchTerms from '../../../uv-core/blocks/utils/fetchTerms';
+
 ( function( wp ) {
     const { createElement } = wp.element;
-    const { useSelect } = wp.data;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
@@ -11,13 +12,7 @@
         edit: function( props ) {
             const { attributes: { location, columns }, setAttributes } = props;
             const query = { per_page: 100 };
-            const { terms, error } = useSelect( function( select ) {
-                const core = select( 'core' );
-                return {
-                    terms: core.getEntityRecords( 'taxonomy', 'uv_location', query ),
-                    error: core.getLastEntityRecordsError ? core.getLastEntityRecordsError( 'taxonomy', 'uv_location', query ) : null
-                };
-            }, [] );
+            const { terms, error } = fetchTerms( 'uv_location', query );
             const options = terms ? terms.map( function( t ) {
                 return { label: t.name, value: t.slug };
             } ) : [];


### PR DESCRIPTION
## Summary
- add reusable fetchTerms utility for taxonomy term caching
- refactor activities, news, partners, and team-grid blocks to use shared helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a80aca88328ba9e14cc5c0bd567