### PR TITLE
Use plugin version constant for asset cache busting

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -13,8 +13,8 @@
 
 if (!defined('ABSPATH')) exit;
 
-if (!defined('UV_CORE_VERSION')) {
-    define('UV_CORE_VERSION', '0.5.0');
+if (!defined('PLUGIN_VERSION')) {
+    define('PLUGIN_VERSION', '0.5.0');
 }
 
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';
@@ -99,7 +99,7 @@ add_action('admin_enqueue_scripts', function($hook){
     $screen = get_current_screen();
     if($screen && $screen->taxonomy === 'uv_location'){
         wp_enqueue_media();
-        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], UV_CORE_VERSION, true);
+        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], PLUGIN_VERSION, true);
         wp_localize_script('uv-term-image', 'uvTermImage', [
             'selectImage' => esc_html__('Select Image', 'uv-core'),
         ]);

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -12,6 +12,10 @@
  */
 if (!defined('ABSPATH')) exit;
 
+if (!defined('PLUGIN_VERSION')) {
+    define('PLUGIN_VERSION', '0.5.0');
+}
+
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';
 if (file_exists($update_checker_path)) {
     require $update_checker_path;
@@ -41,7 +45,7 @@ add_action('admin_enqueue_scripts', function($hook){
             'uv-people-admin',
             plugin_dir_url(__FILE__) . 'assets/admin.js',
             ['jquery', 'select2'],
-            '0.5.0',
+            PLUGIN_VERSION,
             true
         );
         wp_localize_script('uv-people-admin', 'UVPeople', [
@@ -289,7 +293,7 @@ function uv_people_get_avatar($user_id){
 
 // Shortcode: Team grid by location
 function uv_people_team_grid($atts){
-    wp_enqueue_style('uv-team-grid-style');
+    wp_enqueue_style('uv-team-grid-style', plugin_dir_url(__FILE__) . 'blocks/team-grid/style.css', [], PLUGIN_VERSION);
     $a = shortcode_atts(['location'=>'','columns'=>4,'highlight_primary'=>1], $atts);
     if(!$a['location']) return '';
     // Guard against missing uv_location taxonomy when uv-core is inactive or removed


### PR DESCRIPTION
## Summary
- Add PLUGIN_VERSION constant to uv-core and uv-people plugins
- Version admin and public assets with PLUGIN_VERSION to aid cache busting

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c46d9888328b6995bb114aed874