### PR TITLE
Use plugin-specific version constants

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -13,8 +13,8 @@
 
 if (!defined('ABSPATH')) exit;
 
-if (!defined('PLUGIN_VERSION')) {
-    define('PLUGIN_VERSION', '0.5.0');
+if (!defined('UV_CORE_VERSION')) {
+    define('UV_CORE_VERSION', '0.5.0');
 }
 
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';
@@ -99,7 +99,7 @@ add_action('admin_enqueue_scripts', function($hook){
     $screen = get_current_screen();
     if($screen && $screen->taxonomy === 'uv_location'){
         wp_enqueue_media();
-        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], PLUGIN_VERSION, true);
+        wp_enqueue_script('uv-term-image', plugins_url('assets/term-image.js', __FILE__), ['jquery'], UV_CORE_VERSION, true);
         wp_localize_script('uv-term-image', 'uvTermImage', [
             'selectImage' => esc_html__('Select Image', 'uv-core'),
         ]);

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -12,8 +12,8 @@
  */
 if (!defined('ABSPATH')) exit;
 
-if (!defined('PLUGIN_VERSION')) {
-    define('PLUGIN_VERSION', '0.5.0');
+if (!defined('UV_PEOPLE_VERSION')) {
+    define('UV_PEOPLE_VERSION', '0.5.0');
 }
 
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';
@@ -45,7 +45,7 @@ add_action('admin_enqueue_scripts', function($hook){
             'uv-people-admin',
             plugin_dir_url(__FILE__) . 'assets/admin.js',
             ['jquery', 'select2'],
-            PLUGIN_VERSION,
+            UV_PEOPLE_VERSION,
             true
         );
         wp_localize_script('uv-people-admin', 'UVPeople', [
@@ -293,7 +293,7 @@ function uv_people_get_avatar($user_id){
 
 // Shortcode: Team grid by location
 function uv_people_team_grid($atts){
-    wp_enqueue_style('uv-team-grid-style', plugin_dir_url(__FILE__) . 'blocks/team-grid/style.css', [], PLUGIN_VERSION);
+    wp_enqueue_style('uv-team-grid-style', plugin_dir_url(__FILE__) . 'blocks/team-grid/style.css', [], UV_PEOPLE_VERSION);
     $a = shortcode_atts(['location'=>'','columns'=>4,'highlight_primary'=>1], $atts);
     if(!$a['location']) return '';
     // Guard against missing uv_location taxonomy when uv-core is inactive or removed


### PR DESCRIPTION
## Summary
- replace shared PLUGIN_VERSION constant with UV_CORE_VERSION in uv-core plugin
- replace PLUGIN_VERSION with UV_PEOPLE_VERSION for uv-people scripts and styles
- verify no other references to PLUGIN_VERSION remain

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f03aa648328b8aa2edbaed46212