### PR TITLE
Add metadata headers for shortcode block patterns

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -65,7 +65,7 @@ add_action('init', function() {
             'uv-kadence-child/' . $slug,
             [
                 'title'   => $title,
-                'content' => include get_theme_file_path('patterns/' . $slug . '.php'),
+                'content' => include get_theme_file_path('shortcode-patterns/' . $slug . '.php'),
             ]
         );
     }

--- a/themes/uv-kadence-child/patterns/activities.php
+++ b/themes/uv-kadence-child/patterns/activities.php
@@ -1,3 +1,0 @@
-<?php
-return '<!-- wp:shortcode -->[uv_activities columns="3"]<!-- /wp:shortcode -->';
-

--- a/themes/uv-kadence-child/patterns/news-list.php
+++ b/themes/uv-kadence-child/patterns/news-list.php
@@ -1,3 +1,0 @@
-<?php
-return '<!-- wp:shortcode -->[uv_news count="3"]<!-- /wp:shortcode -->';
-

--- a/themes/uv-kadence-child/patterns/partners.php
+++ b/themes/uv-kadence-child/patterns/partners.php
@@ -1,3 +1,0 @@
-<?php
-return '<!-- wp:shortcode -->[uv_partners columns="4"]<!-- /wp:shortcode -->';
-

--- a/themes/uv-kadence-child/shortcode-patterns/activities.php
+++ b/themes/uv-kadence-child/shortcode-patterns/activities.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Title: Activities
+ * Slug: uv-kadence-child/activities
+ * Categories: shortcode
+ */
+return '<!-- wp:shortcode -->[uv_activities columns="3"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/shortcode-patterns/locations-grid.php
+++ b/themes/uv-kadence-child/shortcode-patterns/locations-grid.php
@@ -1,3 +1,8 @@
 <?php
+/**
+ * Title: Locations Grid
+ * Slug: uv-kadence-child/locations-grid
+ * Categories: shortcode
+ */
 return '<!-- wp:shortcode -->[uv_locations_grid columns="3" show_links="1"]<!-- /wp:shortcode -->';
 

--- a/themes/uv-kadence-child/shortcode-patterns/news-list.php
+++ b/themes/uv-kadence-child/shortcode-patterns/news-list.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Title: News List
+ * Slug: uv-kadence-child/news-list
+ * Categories: shortcode
+ */
+return '<!-- wp:shortcode -->[uv_news count="3"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/shortcode-patterns/partners.php
+++ b/themes/uv-kadence-child/shortcode-patterns/partners.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Title: Partners
+ * Slug: uv-kadence-child/partners
+ * Categories: shortcode
+ */
+return '<!-- wp:shortcode -->[uv_partners columns="4"]<!-- /wp:shortcode -->';
+

--- a/themes/uv-kadence-child/shortcode-patterns/team-grid.php
+++ b/themes/uv-kadence-child/shortcode-patterns/team-grid.php
@@ -1,3 +1,8 @@
 <?php
+/**
+ * Title: Team Grid
+ * Slug: uv-kadence-child/team-grid
+ * Categories: shortcode
+ */
 return '<!-- wp:shortcode -->[uv_team location="osl" columns="4" highlight_primary="1"]<!-- /wp:shortcode -->';
 


### PR DESCRIPTION
## Summary
- add Title/Slug/Categories headers to Activities, Locations Grid, News List, Partners, and Team Grid patterns
- move pattern files to `shortcode-patterns` directory and load them manually

## Testing
- `php -l themes/uv-kadence-child/shortcode-patterns/activities.php`
- `php -l themes/uv-kadence-child/shortcode-patterns/locations-grid.php`
- `php -l themes/uv-kadence-child/shortcode-patterns/news-list.php`
- `php -l themes/uv-kadence-child/shortcode-patterns/partners.php`
- `php -l themes/uv-kadence-child/shortcode-patterns/team-grid.php`
- `php -l themes/uv-kadence-child/functions.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6eac036c8328b3093f1ee0f29281