### PR TITLE
Improve team member layout and avatar styling

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -5,16 +5,22 @@
 }
 .uv-team-grid .uv-person {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: clamp(.5rem, 2vw, 1rem);
+    flex-wrap: wrap;
     text-decoration: none;
     height: 100%;
 }
 .uv-team-grid .uv-avatar img {
-    border-radius: 12px;
-    width: 100%;
-    height: auto;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.uv-team-grid .uv-info {
+    flex: 1 1 200px;
+    min-width: 0;
 }
 .uv-team-grid .uv-info > *:empty {
     display: none;

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -8,7 +8,9 @@
 .uv-card .uv-card-body{padding:12px}
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{outline:3px solid var(--uv-purple)}
-.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;gap:.5rem;height:100%}
+.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:row;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);flex-wrap:wrap;height:100%}
+.uv-avatar img{width:80px;height:80px;border-radius:50%;object-fit:cover}
+.uv-info{flex:1 1 200px;min-width:0}
 .uv-person h3{margin:.3rem 0 0;font-size:1.1rem;color:var(--uv-purple)}
 .uv-person .uv-role{font-size:.95rem;color:#555;margin-top:.2rem}
 .uv-person .uv-quote{margin:.5rem 0 0;padding:0;font-style:italic;color:#333}


### PR DESCRIPTION
## Summary
- Align `.uv-person` content horizontally with responsive gaps
- Constrain avatar images to circular 80px squares
- Let `.uv-info` flex beside avatars for better wrapping on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac75a028f08328a914c1edc862084c