### PR TITLE
Highlight primary team members in grid

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -32,3 +32,22 @@
     font-style: italic;
     color: #333;
 }
+
+/* Highlight primary contacts */
+.uv-team-grid .uv-person.uv-primary-contact {
+    border: 2px solid var(--uv-purple, #7a00cc);
+    position: relative;
+}
+
+.uv-team-grid .uv-person.uv-primary-contact::after {
+    content: "★";
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: var(--uv-purple, #7a00cc);
+    color: #fff;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 2px 4px;
+    border-radius: 3px;
+}

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -10,6 +10,9 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
   - `columns` (default: 4) number of columns in the grid.
   - `highlight_primary` (0 or 1) emphasize primary team members.
 
+### Sorting
+Primary contacts are shown first in the grid, followed by other members sorted by their custom order weight and then alphabetically by display name.
+
 ## Usage
 
 ```html

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -7,7 +7,8 @@
 .uv-card a{display:block;text-decoration:none}
 .uv-card .uv-card-body{padding:12px}
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
-.uv-primary-contact{outline:3px solid var(--uv-purple)}
+.uv-primary-contact{position:relative;border:2px solid var(--uv-purple);border-radius:var(--uv-radius)}
+.uv-primary-contact::after{content:"★";position:absolute;top:4px;right:4px;background:var(--uv-purple);color:#fff;font-size:.75rem;line-height:1;padding:2px 4px;border-radius:3px}
 .uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:row;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);flex-wrap:wrap;height:100%}
 .uv-avatar img{width:80px;height:80px;border-radius:50%;object-fit:cover}
 .uv-info{flex:1 1 200px;min-width:0}


### PR DESCRIPTION
## Summary
- add badge and border to `.uv-primary-contact` in block and theme styles
- document that team grid sorts primary contacts first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7a622b488328b8a90ee694730fd1