### PR TITLE
feat: equalize partner card dimensions

### DIFF
--- a/plugins/uv-core/blocks/partners/style.css
+++ b/plugins/uv-core/blocks/partners/style.css
@@ -1,6 +1,7 @@
 .uv-card-list {
     display: grid;
     gap: 1.5rem;
+    align-items: stretch;
 }
 .uv-card {
     list-style: none;

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -3,7 +3,7 @@
   --uv-radius:16px;
 }
 .uv-card-list{list-style:none;display:grid;gap:1rem;padding:0}
-.uv-card{border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);overflow:hidden;background:#fff}
+.uv-card{display:flex;flex-direction:column;min-height:200px;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);overflow:hidden;background:#fff}
 .uv-card a{display:block;text-decoration:none}
 .uv-card .uv-card-body{padding:12px}
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}


### PR DESCRIPTION
## Summary
- make `.uv-card` a flex column with a minimum height
- ensure partner card lists stretch items to fill their grid cells

## Testing
- `npm test`
- `npm install puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8001e2e48328af5d98d0e205c74b