### PR TITLE
Use column classes for team grid layout

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -311,7 +311,7 @@ function uv_people_team_grid($atts){
         ]
     ]);
     if(!$q->have_posts()) return '';
-    $cols = intval($a['columns']);
+    $cols = max(1, min(6, intval($a['columns'])));
     $items = [];
     while($q->have_posts()){ $q->the_post();
         $items[] = [
@@ -334,7 +334,7 @@ function uv_people_team_grid($atts){
     });
     $lang = function_exists('pll_current_language') ? pll_current_language('slug') : substr(get_locale(),0,2);
     ob_start();
-    echo '<div class="uv-team-grid" role="list" style="grid-template-columns:repeat('.$cols.',1fr)">';
+    echo '<div class="uv-team-grid columns-'.$cols.'" role="list">';
     foreach($items as $it){
         $uid = intval($it['user_id']);
         $name = get_the_author_meta('display_name', $uid);

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -20,3 +20,11 @@
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}
 .uv-partner--title_only .uv-card-body{text-align:center}
 .uv-partner-icon{display:block;width:100%;aspect-ratio:1;background:#f0f0f0}
+
+/* Responsive team grid column classes */
+.uv-team-grid{display:grid;gap:1.5rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+@media (min-width:600px){.uv-team-grid.columns-2{grid-template-columns:repeat(2,1fr)}}
+@media (min-width:900px){.uv-team-grid.columns-3{grid-template-columns:repeat(3,1fr)}}
+@media (min-width:1200px){.uv-team-grid.columns-4{grid-template-columns:repeat(4,1fr)}}
+@media (min-width:1500px){.uv-team-grid.columns-5{grid-template-columns:repeat(5,1fr)}}
+@media (min-width:1800px){.uv-team-grid.columns-6{grid-template-columns:repeat(6,1fr)}}


### PR DESCRIPTION
## Summary
- switch team grid shortcode to use column classes instead of inline grid styles
- add responsive column helpers to theme CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac815d2fc88328a1b6ebe5f8f90289