### PR TITLE
Refactor team grid markup and styling

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -5,32 +5,80 @@
 }
 .uv-team-grid .uv-person {
     display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    gap: clamp(.5rem, 2vw, 1rem);
-    flex-wrap: wrap;
-    text-decoration: none;
+    flex-direction: column;
+    background: #fff;
+    border-radius: var(--uv-radius, 8px);
+    box-shadow: 0 6px 18px rgba(0,0,0,.08);
+    padding: 1rem;
     height: 100%;
 }
+.uv-team-grid .uv-person > a {
+    display: flex;
+    align-items: flex-start;
+    gap: clamp(.5rem, 2vw, 1rem);
+    text-decoration: none;
+    color: inherit;
+}
 .uv-team-grid .uv-avatar img {
-    width: 80px;
-    height: 80px;
+    width: 96px;
+    height: 96px;
     border-radius: 50%;
     object-fit: cover;
 }
 .uv-team-grid .uv-info {
-    flex: 1 1 200px;
+    flex: 1 1 auto;
     min-width: 0;
 }
 .uv-team-grid .uv-info > *:empty {
     display: none;
 }
 
+.uv-team-grid .uv-person h3 {
+    margin: .3rem 0 0;
+    color: var(--uv-purple, #7a00cc);
+    font-size: 1.25rem;
+}
+
+.uv-team-grid .uv-contact {
+    margin-top: .75rem;
+}
+.uv-team-grid .uv-contact .label {
+    font-weight: 600;
+    margin-right: .25rem;
+}
+.uv-team-grid .uv-contact a {
+    color: var(--uv-purple, #7a00cc);
+    text-decoration: none;
+}
+
 .uv-team-grid .uv-quote {
-    margin: .5rem 0 0;
-    padding: 0;
-    font-style: italic;
-    color: #333;
+    margin-top: 1rem;
+    background: var(--uv-yellow, #fff7b2);
+    padding: .75rem 1rem;
+    position: relative;
+}
+.uv-team-grid .uv-quote .uv-quote-icon {
+    font-size: 2rem;
+    line-height: 1;
+    margin-right: .25rem;
+}
+.uv-team-grid .uv-quote::after {
+    content: "\201D";
+    position: absolute;
+    right: .5rem;
+    bottom: .25rem;
+    font-size: 2rem;
+    line-height: 1;
+}
+
+@media (max-width: 600px) {
+    .uv-team-grid {
+        grid-template-columns: 1fr;
+    }
+    .uv-team-grid .uv-person > a {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }
 
 /* Highlight primary contacts */

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -352,7 +352,8 @@ function uv_people_team_grid($atts){
         // Link each card to custom team template
         $url = add_query_arg('team', '1', get_author_posts_url($uid));
         $label = sprintf(__('View profile for %s','uv-people'), $name);
-        echo '<a class="'.esc_attr($classes).'" href="'.esc_url($url).'" aria-label="'.esc_attr($label).'" role="listitem">';
+        echo '<article class="'.esc_attr($classes).'" role="listitem">';
+        echo '<a href="'.esc_url($url).'" aria-label="'.esc_attr($label).'">';
         echo '<div class="uv-avatar">'.uv_people_get_avatar($uid).'</div>';
         echo '<div class="uv-info">';
         echo '<h3>'.esc_html($name).'</h3>';
@@ -365,17 +366,20 @@ function uv_people_team_grid($atts){
         $quote_nb = get_user_meta($uid,'uv_quote_nb',true);
         $quote_en = get_user_meta($uid,'uv_quote_en',true);
         $quote = ($lang==='en') ? ($quote_en ?: $quote_nb) : ($quote_nb ?: $quote_en);
-        if($quote) echo '<blockquote class="uv-quote">'.esc_html($quote).'</blockquote>';
+        echo '</div>';
+        echo '</a>';
         // contact visibility
         $show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
         if(($phone && $show_phone) || $email){
+            $email_label = ($lang==='en') ? __('Email:','uv-people') : __('E-post:','uv-people');
+            $phone_label = ($lang==='en') ? __('Mobile:','uv-people') : __('Mobil:','uv-people');
             echo '<div class="uv-contact">';
-            if($phone && $show_phone) echo '<div><a href="tel:'.esc_attr($phone).'">'.esc_html($phone).'</a></div>';
-            if($email) echo '<div><a href="mailto:'.esc_attr($email).'">'.esc_html($email).'</a></div>';
+            if($email) echo '<div class="uv-email"><span class="label">'.esc_html($email_label).'</span><a href="mailto:'.esc_attr($email).'">'.esc_html($email).'</a></div>';
+            if($phone && $show_phone) echo '<div class="uv-mobile"><span class="label">'.esc_html($phone_label).'</span><a href="tel:'.esc_attr($phone).'">'.esc_html($phone).'</a></div>';
             echo '</div>';
         }
-        echo '</div>';
-        echo '</a>';
+        if($quote) echo '<div class="uv-quote"><span class="uv-quote-icon">&ldquo;</span>'.esc_html($quote).'</div>';
+        echo '</article>';
     }
     echo '</div>';
     return ob_get_clean();

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -1,6 +1,7 @@
 :root{
   --uv-purple:#7a00cc;
   --uv-radius:16px;
+  --uv-yellow:#fff7b2;
 }
 .uv-card-list{list-style:none;display:grid;gap:1rem;padding:0}
 .uv-card{display:flex;flex-direction:column;min-height:200px;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);overflow:hidden;background:#fff}
@@ -9,12 +10,18 @@
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{position:relative;border:2px solid var(--uv-purple);border-radius:var(--uv-radius)}
 .uv-primary-contact::after{content:"★";position:absolute;top:4px;right:4px;background:var(--uv-purple);color:#fff;font-size:.75rem;line-height:1;padding:2px 4px;border-radius:3px}
-.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:row;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);flex-wrap:wrap;height:100%}
-.uv-avatar img{width:80px;height:80px;border-radius:50%;object-fit:cover}
-.uv-info{flex:1 1 200px;min-width:0}
-.uv-person h3{margin:.3rem 0 0;font-size:1.1rem;color:var(--uv-purple)}
+.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;height:100%}
+.uv-person>a{display:flex;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);text-decoration:none;color:inherit}
+.uv-avatar img{width:96px;height:96px;border-radius:50%;object-fit:cover}
+.uv-info{flex:1 1 auto;min-width:0}
+.uv-person h3{margin:.3rem 0 0;font-size:1.25rem;color:var(--uv-purple)}
 .uv-person .uv-role{font-size:.95rem;color:#555;margin-top:.2rem}
-.uv-person .uv-quote{margin:.5rem 0 0;padding:0;font-style:italic;color:#333}
+.uv-person .uv-contact{margin-top:.75rem}
+.uv-person .uv-contact .label{font-weight:600;margin-right:.25rem}
+.uv-person .uv-contact a{color:var(--uv-purple);text-decoration:none}
+.uv-person .uv-quote{margin-top:1rem;background:var(--uv-yellow);padding:.75rem 1rem;position:relative}
+.uv-person .uv-quote .uv-quote-icon{font-size:2rem;line-height:1;margin-right:.25rem}
+.uv-person .uv-quote:after{content:"\201D";position:absolute;right:.5rem;bottom:.25rem;font-size:2rem;line-height:1}
 .uv-card-body h3{margin:0;font-size:1rem}
 
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}


### PR DESCRIPTION
## Summary
- wrap team members in `<article>` with dedicated contact info and quote blocks
- style team cards with purple headings, larger avatars, and yellow quote bars
- add `--uv-yellow` theme variable and update responsive layout

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad536e419c8328bc3f09d3c9491b4e