### PR TITLE
Add partner card layout options with defaults

### DIFF
--- a/docs/BLOCKS.md
+++ b/docs/BLOCKS.md
@@ -24,7 +24,7 @@
   - `location` (string, default empty)
   - `type` (string, default empty)
   - `columns` (number, default 4)
-- **Partner display options:** `logo_only`, `logo_title`, `circle_title`, `icon_title`
+- **Partner display options:** `circle_title`, `logo_only`, `logo_title`, `title_only`
 
 ## Team Grid
 - **Block name:** `uv/team-grid`

--- a/docs/EDITOR-GUIDE.md
+++ b/docs/EDITOR-GUIDE.md
@@ -13,9 +13,10 @@ Simple steps for managing common content types in the WordPress dashboard.
 1. Go to **Partners → Add New**.
 2. Add a title and description.
 3. Use **Set featured image** for the partner logo if available.
-4. In the sidebar, assign a **Location** and, if needed, a **Partner Type**.
-5. In the **External URL** field, paste the partner's website.
-6. Publish the Partner.
+4. From the **Display** dropdown, choose the card layout (circle image & title, logo only, logo with title, or title only).
+5. In the sidebar, assign a **Location** and, if needed, a **Partner Type**.
+6. In the **External URL** field, paste the partner's website.
+7. Publish the Partner.
 
 ## Team Members
 1. Go to **Users → Add New** (or edit an existing user).

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -18,7 +18,7 @@ UV Core registers CPTs, taxonomies, and shortcodes.
   - `location` (optional) Location slug.
   - `type` (optional) Partner Type slug.
   - `columns` (default: 4) number of columns.
-  - Each Partner post has a **Display** option: `logo_only`, `logo_title`, `circle_title`, or `icon_title`.
+  - Each Partner post has a **Display** option: `circle_title` (default), `logo_only`, `logo_title`, or `title_only`.
 
 ## Usage
 

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -360,7 +360,8 @@ function uv_core_partners($atts){
         while($q->have_posts()){ $q->the_post();
             $link = get_post_meta(get_the_ID(), 'uv_partner_url', true);
             $display = get_post_meta(get_the_ID(), 'uv_partner_display', true);
-            if(!$display) $display = 'logo_title';
+            if(!$display) $display = has_post_thumbnail() ? 'circle_title' : 'title_only';
+            if(!has_post_thumbnail()) $display = 'title_only';
             $classes = 'uv-card uv-partner uv-partner--'.esc_attr($display);
             echo '<li class="'.$classes.'">';
             echo $link ? '<a href="'.esc_url($link).'" rel="noopener nofollow">' : '<a href="'.esc_url(get_permalink()).'">';
@@ -379,10 +380,6 @@ function uv_core_partners($atts){
                     break;
                 case 'circle_title':
                     $render_thumb(['class'=>'is-circle']);
-                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div>';
-                    break;
-                case 'icon_title':
-                    $render_thumb(['class'=>'is-icon']);
                     echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div>';
                     break;
                 case 'title_only':
@@ -413,7 +410,7 @@ add_action('add_meta_boxes_uv_partner', function(){
     }, 'side');
     add_meta_box('uv_partner_display', esc_html__('Display','uv-core'), function($post){
         $val = get_post_meta($post->ID, 'uv_partner_display', true);
-        if(!$val) $val = 'logo_title';
+        if(!$val) $val = has_post_thumbnail($post->ID) ? 'circle_title' : 'title_only';
         wp_nonce_field('uv_partner_display_action', 'uv_partner_display_nonce');
         echo '<p><label class="screen-reader-text" for="uv_partner_display">'.esc_html__('Display','uv-core').'</label>';
         echo '<select id="uv_partner_display" name="uv_partner_display">';
@@ -421,7 +418,6 @@ add_action('add_meta_boxes_uv_partner', function(){
             'logo_only'   => esc_html__('Logo only','uv-core'),
             'logo_title'  => esc_html__('Logo and title','uv-core'),
             'circle_title'=> esc_html__('Circle & title','uv-core'),
-            'icon_title'  => esc_html__('Icon & title','uv-core'),
             'title_only'  => esc_html__('Title only','uv-core'),
         ];
         foreach($opts as $k=>$label){
@@ -443,8 +439,8 @@ add_action('save_post_uv_partner', function($post_id){
     if(isset($_POST['uv_partner_display_nonce'])){
         check_admin_referer('uv_partner_display_action', 'uv_partner_display_nonce');
         if(isset($_POST['uv_partner_display'])){
-            $allowed = ['logo_only','logo_title','circle_title','icon_title','title_only'];
-            $val = in_array($_POST['uv_partner_display'],$allowed) ? $_POST['uv_partner_display'] : 'logo_title';
+            $allowed = ['logo_only','logo_title','circle_title','title_only'];
+            $val = in_array($_POST['uv_partner_display'],$allowed) ? $_POST['uv_partner_display'] : 'circle_title';
             update_post_meta($post_id, 'uv_partner_display', $val);
         }
     }

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -25,6 +25,9 @@
 .uv-card-body h3{margin:0;font-size:1rem}
 
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}
+.uv-partner img{display:block;width:100%;height:auto;object-fit:contain}
+.uv-partner--circle_title img.is-circle{width:120px;height:120px;margin:1rem auto 0;border-radius:50%;object-fit:cover}
+.uv-partner--circle_title .uv-card-body{text-align:center}
 .uv-partner--title_only .uv-card-body{text-align:center}
 .uv-partner-icon{display:block;width:100%;aspect-ratio:1;background:#f0f0f0}
 


### PR DESCRIPTION
## Summary
- allow partners to choose circle, logo only, logo with title or title only layouts
- fallback to title-only when no image is supplied
- document new partner card options and usage

## Testing
- `npm test`
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad550b52808328bb52de97306ae1be