### PR TITLE
style: unify person borders and simplify primary contact

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -11,6 +11,7 @@
     box-shadow: 0 6px 18px rgba(0,0,0,.08);
     padding: 1rem;
     height: 100%;
+    border: 1px solid var(--uv-border, #ddd);
 }
 .uv-team-grid .uv-person > a {
     display: flex;
@@ -84,18 +85,4 @@
 /* Highlight primary contacts */
 .uv-team-grid .uv-person.uv-primary-contact {
     border: 2px solid var(--uv-purple, #7a00cc);
-    position: relative;
-}
-
-.uv-team-grid .uv-person.uv-primary-contact::after {
-    content: "★";
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    background: var(--uv-purple, #7a00cc);
-    color: #fff;
-    font-size: 0.75rem;
-    line-height: 1;
-    padding: 2px 4px;
-    border-radius: 3px;
 }

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -8,9 +8,8 @@
 .uv-card a{display:block;text-decoration:none}
 .uv-card .uv-card-body{padding:12px}
 .uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
-.uv-primary-contact{position:relative;border:2px solid var(--uv-purple);border-radius:var(--uv-radius)}
-.uv-primary-contact::after{content:"★";position:absolute;top:4px;right:4px;background:var(--uv-purple);color:#fff;font-size:.75rem;line-height:1;padding:2px 4px;border-radius:3px}
-.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;height:100%}
+.uv-primary-contact{border:2px solid var(--uv-purple);border-radius:var(--uv-radius)}
+.uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;height:100%;border:1px solid var(--uv-border,#ddd)}
 .uv-person>a{display:flex;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);text-decoration:none;color:inherit}
 .uv-avatar img{width:96px;height:96px;border-radius:50%;object-fit:cover}
 .uv-info{flex:1 1 auto;min-width:0}


### PR DESCRIPTION
## Summary
- add neutral border to team grid person blocks
- highlight primary contacts with purple border only and remove star decoration
- mirror person and primary contact border styles in theme CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5d9b73b08328b427bd0bd00bf5ed