### PR TITLE
Clarify team grid sorting priorities

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -332,7 +332,7 @@ function uv_people_team_grid($atts){
         ];
     }
     wp_reset_postdata();
-    // sort: primary desc, order asc, name asc
+    // sort priority: primary ➜ order weight ➜ name
     usort($items, function($a,$b){
         if($a['primary'] !== $b['primary']) return $a['primary']? -1 : 1;
         if($a['order'] !== $b['order']) return $a['order'] < $b['order'] ? -1 : 1;


### PR DESCRIPTION
## Summary
- document that team grid sorts by primary members, then order weight, then name

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5faedbf483289bc1d8167d25360b