### PR TITLE
chore: bump version to 0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It’s designed for **shared hosting**, with a focus on **accessibility, perform
 - **v0.5.1:** Runtime environment checks and unique version constants.
 - **v0.5.2:** Bug fixes and maintenance release.
 - **v0.5.3:** Version bump for release.
+- **v0.5.4:** Version bump for release.
 - **v1.0.0:** Fully bilingual content with streamlined deployment and contributor workflows.
 
 ## Contents
@@ -94,19 +95,19 @@ While deploying or migrating, enable **Maintenance** plugin (already installed),
 - Add your how-to videos/links in **Dashboard → Team Guide** widget (config in `uv-people`).
 
 ## Building ZIPs from GitHub
-Tag a release like `v0.5.3` and GitHub Actions will attach zips for the child theme and each plugin.
+Tag a release like `v0.5.4` and GitHub Actions will attach zips for the child theme and each plugin.
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
 See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
 ### Tagging and making releases
 1. Commit your changes and push them to GitHub.
 2. In the repository, click **Releases** → **Draft a new release**.
-3. In **Tag version**, enter a new tag like `v0.5.3` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
+3. In **Tag version**, enter a new tag like `v0.5.4` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
 4. Choose **Create new tag on publish**, leaving the target branch as `main`.
 5. Add a title and notes, then click **Publish release**. GitHub Actions will build ZIPs for the theme and each plugin and attach them to the release.
 6. After the workflow completes, download the ZIPs from the release page and upload them to WordPress to update.
 
-> To tag from the command line instead, run `git tag v0.5.3 && git push origin v0.5.3` before drafting the release.
+> To tag from the command line instead, run `git tag v0.5.4 && git push origin v0.5.4` before drafting the release.
 
 ---
 © 2025 Unge Vil. MIT License.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -2,7 +2,7 @@
 
 ## 1. Get the new ZIPs
 1. Visit the repository's [Releases](https://github.com/ungevil/Unge-Vil-Website/releases) page.
-2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `v0.5.3`).
+2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `v0.5.4`).
 
 ## 2. Back up the site
 1. In your hosting panel or backup plugin (e.g. UpdraftPlus), run a full backup.
@@ -21,6 +21,6 @@
 3. Click **Install Now**, choose **Replace current version** when asked, then **Activate**.
 
 ## 4. Verify versions
-1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.5.3`).
+1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.5.4`).
 2. In **Appearance → Themes**, open the child theme details and verify its version.
 3. Browse a few pages on the front‑end to confirm the site loads as expected.

--- a/plugins/uv-core/languages/uv-core.pot
+++ b/plugins/uv-core/languages/uv-core.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-core 0.5.3\n"
+"Project-Id-Version: uv-core 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-25 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -34,6 +34,8 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.
 
 ## Changelog
+### 0.5.4
+- Version bump for release.
 ### 0.5.3
 - Version bump for release.
 ### 0.5.2

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Core
  * Description: CPTs, taxonomies, term images, and lightweight shortcodes.
- * Version: 0.5.3
+ * Version: 0.5.4
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil
@@ -39,7 +39,7 @@ if (!$uv_core_php_ok || !$uv_core_wp_ok) {
 }
 
 if (!defined('UV_CORE_VERSION')) {
-    define('UV_CORE_VERSION', '0.5.3');
+    define('UV_CORE_VERSION', '0.5.4');
 }
 
 $update_checker_path = dirname(__DIR__, 2) . '/plugin-update-checker/plugin-update-checker.php';

--- a/plugins/uv-events-bridge/languages/uv-events-bridge.pot
+++ b/plugins/uv-events-bridge/languages/uv-events-bridge.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-events-bridge 0.5.3\n"
+"Project-Id-Version: uv-events-bridge 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-25 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -23,6 +23,8 @@ UV Events Bridge connects Locations to The Events Calendar.
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.
 
 ## Changelog
+### 0.5.4
+- Version bump for release.
 ### 0.5.3
 - Version bump for release.
 ### 0.5.2

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Events Bridge
  * Description: Adds uv_location taxonomy to The Events Calendar events and provides an upcoming events shortcode.
- * Version: 0.5.3
+ * Version: 0.5.4
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil

--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-people 0.5.3\n"
+"Project-Id-Version: uv-people 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-25 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -27,6 +27,8 @@ Primary contacts are shown first in the grid, followed by other members sorted b
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.5.4
+- Version bump for release.
 ### 0.5.3
 - Version bump for release.
 ### 0.5.2

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
- * Version: 0.5.3
+ * Version: 0.5.4
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil
@@ -13,7 +13,7 @@
 if (!defined('ABSPATH')) exit;
 
 if (!defined('UV_PEOPLE_VERSION')) {
-    define('UV_PEOPLE_VERSION', '0.5.3');
+    define('UV_PEOPLE_VERSION', '0.5.4');
 }
 
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Theme Name: UV Kadence Child
-Version: 0.5.3
+Version: 0.5.4
 */
 $update_checker_path = dirname(__DIR__, 2) . '/plugin-update-checker/plugin-update-checker.php';
 if (file_exists($update_checker_path)) {

--- a/themes/uv-kadence-child/languages/uv-kadence-child.pot
+++ b/themes/uv-kadence-child/languages/uv-kadence-child.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-kadence-child 0.5.3\n"
+"Project-Id-Version: uv-kadence-child 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-21 08:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/themes/uv-kadence-child/readme.md
+++ b/themes/uv-kadence-child/readme.md
@@ -1,6 +1,8 @@
 Kadence child theme for Unge Vil.
 
 ## Changelog
+### 0.5.4
+- Version bump for release.
 ### 0.5.3
 - Version bump for release.
 ### 0.5.2

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -4,6 +4,6 @@
  Text Domain: uv-kadence-child
  Author: Unge Vil
  Author URI: https://www.ungevil.no/
- Version: 0.5.3
+ Version: 0.5.4
  Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/themes/uv-kadence-child
 */


### PR DESCRIPTION
## Summary
- bump theme and plugin headers to v0.5.4 and update internal version constants
- refresh docs and changelogs for the 0.5.4 release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad61de3be88328a87568aaa4969115