### PR TITLE
Expose partner meta fields in REST and block editor

### DIFF
--- a/plugins/uv-core/assets/partner-meta.js
+++ b/plugins/uv-core/assets/partner-meta.js
@@ -1,0 +1,57 @@
+(function (wp) {
+    var registerPlugin = wp.plugins.registerPlugin;
+    var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+    var __ = wp.i18n.__;
+    var TextControl = wp.components.TextControl;
+    var SelectControl = wp.components.SelectControl;
+    var withSelect = wp.data.withSelect;
+    var withDispatch = wp.data.withDispatch;
+    var compose = wp.compose.compose;
+
+    var PartnerMetaPanel = compose(
+        withSelect(function (select) {
+            return { meta: select('core/editor').getEditedPostAttribute('meta') };
+        }),
+        withDispatch(function (dispatch) {
+            return {
+                updateMeta: function (meta) {
+                    dispatch('core/editor').editPost({ meta: meta });
+                }
+            };
+        })
+    )(function (props) {
+        return wp.element.createElement(
+            PluginDocumentSettingPanel,
+            {
+                name: 'uv-partner-meta',
+                title: __('Partner Details', 'uv-core'),
+                className: 'uv-partner-meta-panel'
+            },
+            wp.element.createElement(TextControl, {
+                label: __('External URL', 'uv-core'),
+                value: props.meta.uv_partner_url || '',
+                onChange: function (value) {
+                    props.updateMeta({ uv_partner_url: value });
+                }
+            }),
+            wp.element.createElement(SelectControl, {
+                label: __('Display', 'uv-core'),
+                value: props.meta.uv_partner_display || 'circle_title',
+                options: [
+                    { label: __('Logo only', 'uv-core'), value: 'logo_only' },
+                    { label: __('Logo and title', 'uv-core'), value: 'logo_title' },
+                    { label: __('Circle & title', 'uv-core'), value: 'circle_title' },
+                    { label: __('Title only', 'uv-core'), value: 'title_only' }
+                ],
+                onChange: function (value) {
+                    props.updateMeta({ uv_partner_display: value });
+                }
+            })
+        );
+    });
+
+    registerPlugin('uv-partner-meta', {
+        render: PartnerMetaPanel
+    });
+})(window.wp);
+

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -446,6 +446,43 @@ add_action('save_post_uv_partner', function($post_id){
     }
 });
 
+function uv_core_sanitize_partner_display($val){
+    $allowed = ['logo_only','logo_title','circle_title','title_only'];
+    return in_array($val, $allowed, true) ? $val : 'circle_title';
+}
+
+add_action('init', function(){
+    register_post_meta('uv_partner', 'uv_partner_url', [
+        'single' => true,
+        'type' => 'string',
+        'show_in_rest' => true,
+        'default' => '',
+        'sanitize_callback' => 'esc_url_raw',
+        'auth_callback' => function(){ return current_user_can('edit_posts'); },
+    ]);
+    register_post_meta('uv_partner', 'uv_partner_display', [
+        'single' => true,
+        'type' => 'string',
+        'show_in_rest' => true,
+        'default' => 'circle_title',
+        'sanitize_callback' => 'uv_core_sanitize_partner_display',
+        'auth_callback' => function(){ return current_user_can('edit_posts'); },
+    ]);
+});
+
+add_action('enqueue_block_editor_assets', function(){
+    $screen = get_current_screen();
+    if($screen && $screen->base === 'post' && $screen->post_type === 'uv_partner'){
+        wp_enqueue_script(
+            'uv-partner-meta',
+            plugins_url('assets/partner-meta.js', __FILE__),
+            ['wp-plugins','wp-edit-post','wp-element','wp-components','wp-data','wp-compose','wp-i18n'],
+            UV_CORE_VERSION,
+            true
+        );
+    }
+});
+
 // Related post meta box for experiences
 add_action('add_meta_boxes_uv_experience', function(){
     add_meta_box('uv_related_post', esc_html__('Related Post','uv-core'), function($post){


### PR DESCRIPTION
## Summary
- Register `uv_partner_url` and `uv_partner_display` as REST-exposed post meta with defaults and sanitizers
- Add Gutenberg sidebar panel to edit partner URL and display options

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6638dc608328826b5491bb8ef55f