### PR TITLE
Ensure partner cards display description when available

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -387,8 +387,11 @@ function uv_core_partners($atts){
                     break;
                 default:
                     $render_thumb();
-                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong>';
-                    if(has_excerpt()) echo '<div>'.esc_html(get_the_excerpt()).'</div>';
+                    echo '<div class="uv-card-body"><strong>' . esc_html( get_the_title() ) . '</strong>';
+                    $excerpt = get_the_excerpt();
+                    if ( $excerpt ) {
+                        echo '<div>' . esc_html( $excerpt ) . '</div>';
+                    }
                     echo '</div>';
                     break;
             }


### PR DESCRIPTION
## Summary
- show partner card descriptions when an excerpt is present

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test`
- `php -r 'function esc_html($s){return $s;} function get_the_title(){return "Title";} function get_the_excerpt(){return "Excerpt";} ob_start(); echo "<div class=\\"uv-card-body\\"><strong>" . esc_html(get_the_title()) . "</strong>"; $excerpt = get_the_excerpt(); if ($excerpt) { echo "<div>" . esc_html($excerpt) . "</div>"; } echo "</div>"; $output=ob_get_clean(); echo $output, "\\n";'`

------
https://chatgpt.com/codex/tasks/task_e_68ad6715e9388328b0521e9be3501941