### PR TITLE
Remove editor field from Partner post type

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -107,7 +107,7 @@ add_action('init', function(){
         'show_in_rest' => true,
         'has_archive' => true,
         'menu_icon' => 'dashicons-heart',
-        'supports' => ['title','editor','thumbnail','excerpt'],
+        'supports' => ['title','thumbnail','excerpt'],
         'taxonomies' => ['uv_location','uv_partner_type'],
     ]);
     register_post_type('uv_experience', [


### PR DESCRIPTION
## Summary
- remove `editor` support from `uv_partner` post type so only title, thumbnail, excerpt remain

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad688143888328b9c934dcb2685987