### PR TITLE
Remove location taxonomy from experiences

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -72,7 +72,7 @@ add_action('plugins_loaded', function(){
 
 add_action('init', function(){
     // Taxonomies
-    register_taxonomy('uv_location', ['post','uv_activity','uv_partner','uv_experience'], [
+    register_taxonomy('uv_location', ['post','uv_activity','uv_partner'], [
         'label' => esc_html__('Locations', 'uv-core'),
         'public' => true,
         'hierarchical' => true,
@@ -117,7 +117,6 @@ add_action('init', function(){
         'has_archive' => true,
         'menu_icon' => 'dashicons-awards',
         'supports' => ['title','editor','thumbnail','excerpt','custom-fields'],
-        'taxonomies' => ['uv_location'],
     ]);
 });
 


### PR DESCRIPTION
## Summary
- detach `uv_location` taxonomy from `uv_experience` post type
- confirm no code expects experiences to have locations

## Testing
- `npm test`
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6c3c836c8328a99eb17834fa7499