### PR TITLE
Add workflow to package theme and plugin zips on release

### DIFF
--- a/.github/workflows/package-zips.yml
+++ b/.github/workflows/package-zips.yml
@@ -1,0 +1,26 @@
+name: Package ZIPs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create plugin and theme ZIPs
+        run: |
+          mkdir -p dist
+          for dir in plugins/* themes/*; do
+            if [ -d "$dir" ]; then
+              name="$(basename "$dir")"
+              zip -r "dist/${name}.zip" "$dir"
+            fi
+          done
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.zip


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to zip all plugins and theme and attach to release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6de4bea083289e8d74d3c2f6c7f5