### PR TITLE
Display experience authors

### DIFF
--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -16,6 +16,31 @@ if ( have_posts() ) :
             <h1><?php the_title(); ?></h1>
             <div>
                 <?php the_content(); ?>
+                <?php
+                $users = get_post_meta( get_the_ID(), 'uv_experience_users', true );
+                if ( $users && is_array( $users ) ) :
+                    ?>
+                    <div class="uv-experience-users">
+                        <?php
+                        foreach ( $users as $user_id ) :
+                            $user_id = absint( $user_id );
+                            $user    = get_user_by( 'id', $user_id );
+
+                            if ( ! $user ) {
+                                continue;
+                            }
+                            ?>
+                            <a class="uv-experience-user" href="<?php echo esc_url( get_author_posts_url( $user_id ) ); ?>">
+                                <?php echo get_avatar( $user_id, 48 ); ?>
+                                <span class="uv-experience-user-name"><?php echo esc_html( $user->display_name ); ?></span>
+                            </a>
+                            <?php
+                        endforeach;
+                        ?>
+                    </div>
+                    <?php
+                endif;
+                ?>
             </div>
             <?php
             $related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );


### PR DESCRIPTION
## Summary
- show users linked to a UV experience after the content

## Testing
- `php -l themes/uv-kadence-child/single-uv_experience.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6dbf256c8328a0eea627230c6bc9