### PR TITLE
Add experiences block for uv_experience posts

### DIFF
--- a/plugins/uv-core/blocks/experiences/block.json
+++ b/plugins/uv-core/blocks/experiences/block.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": 2,
+  "name": "uv/experiences",
+  "title": "Experiences",
+  "category": "unge-vil",
+  "icon": "admin-site",
+  "attributes": {
+    "count": {"type": "number", "default": 3}
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-core/blocks/experiences/index.asset.php
+++ b/plugins/uv-core/blocks/experiences/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-core/blocks/experiences/index.js
+++ b/plugins/uv-core/blocks/experiences/index.js
@@ -1,0 +1,42 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
+    const { PanelBody, RangeControl } = wp.components;
+    const ServerSideRender = wp.serverSideRender;
+
+    registerBlockType( 'uv/experiences', {
+        edit: function( props ) {
+            const { attributes: { count }, setAttributes } = props;
+            return createElement( wp.element.Fragment, {},
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-core' ), initialOpen: true },
+                        createElement( RangeControl, {
+                            label: __( 'Count', 'uv-core' ),
+                            min: 1,
+                            max: 10,
+                            value: count,
+                            onChange: function( value ) { setAttributes( { count: value } ); },
+                            style: { height: '40px', marginBottom: 0 }
+                        } )
+                    )
+                ),
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/experiences',
+                        attributes: props.attributes,
+                        LoadingResponsePlaceholder: function() {
+                            return createElement(
+                                'p',
+                                { className: 'uv-block-placeholder' },
+                                __( 'Loading preview…', 'uv-core' )
+                            );
+                        }
+                    } )
+                )
+            );
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp );

--- a/plugins/uv-core/blocks/experiences/style.css
+++ b/plugins/uv-core/blocks/experiences/style.css
@@ -1,0 +1,7 @@
+.uv-card-list {
+    display: grid;
+    gap: 1.5rem;
+}
+.uv-card {
+    list-style: none;
+}

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -338,6 +338,27 @@ function uv_core_activities($atts){
 }
 add_shortcode('uv_activities','uv_core_activities');
 
+function uv_core_experiences($atts){
+    $a = shortcode_atts(['count'=>3], $atts);
+    $args = ['post_type'=>'uv_experience','posts_per_page'=>intval($a['count'])];
+    $q = new WP_Query($args);
+    ob_start();
+    if($q->have_posts()){
+        echo '<ul class="uv-card-list" style="grid-template-columns:repeat(3,1fr)">';
+        while($q->have_posts()){ $q->the_post();
+            echo '<li class="uv-card"><a href="'.esc_url(get_permalink()).'">';
+            if(has_post_thumbnail()) the_post_thumbnail('uv_card',['alt'=>esc_attr(get_the_title())]);
+            echo '<div class="uv-card-body"><h3>'.esc_html(get_the_title()).'</h3>';
+            if(has_excerpt()) echo '<div>'.esc_html(get_the_excerpt()).'</div>';
+            echo '</div></a></li>';
+        }
+        echo '</ul>';
+    }
+    wp_reset_postdata();
+    return ob_get_clean();
+}
+add_shortcode('uv_experiences','uv_core_experiences');
+
 function uv_core_partners($atts){
     $a = shortcode_atts(['location'=>'','type'=>'','columns'=>4], $atts);
     $args = ['post_type'=>'uv_partner','posts_per_page'=>-1];
@@ -582,6 +603,9 @@ add_action('init', function(){
     ]);
     register_block_type(__DIR__ . '/blocks/news', [
         'render_callback' => 'uv_core_posts_news'
+    ]);
+    register_block_type(__DIR__ . '/blocks/experiences', [
+        'render_callback' => 'uv_core_experiences'
     ]);
     register_block_type(__DIR__ . '/blocks/activities', [
         'render_callback' => 'uv_core_activities'


### PR DESCRIPTION
## Summary
- add server-rendered `uv/experiences` block to show `uv_experience` posts
- register experiences block in core plugin with rendering logic

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-core/blocks/experiences/index.asset.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6ea962048328a1a2dc945206d4a4