### PR TITLE
Add all-team-grid block and global team listing

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/block.json
+++ b/plugins/uv-people/blocks/all-team-grid/block.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": 2,
+  "name": "uv/all-team-grid",
+  "title": "All Team Grid",
+  "category": "unge-vil",
+  "icon": "groups",
+  "attributes": {
+    "columns": {
+      "type": "number",
+      "default": 4
+    }
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style.css"
+}

--- a/plugins/uv-people/blocks/all-team-grid/index.asset.php
+++ b/plugins/uv-people/blocks/all-team-grid/index.asset.php
@@ -1,0 +1,1 @@
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.0');

--- a/plugins/uv-people/blocks/all-team-grid/index.js
+++ b/plugins/uv-people/blocks/all-team-grid/index.js
@@ -1,0 +1,44 @@
+( function( wp ) {
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { InspectorControls, useBlockProps } = wp.blockEditor;
+    const { PanelBody, RangeControl } = wp.components;
+    const ServerSideRender = wp.serverSideRender;
+
+    registerBlockType( 'uv/all-team-grid', {
+        edit: function( props ) {
+            const { attributes: { columns }, setAttributes } = props;
+            return createElement( wp.element.Fragment, {},
+                createElement( InspectorControls, {},
+                    createElement( PanelBody, { title: __( 'Settings', 'uv-people' ), initialOpen: true },
+                        createElement( RangeControl, {
+                            label: __( 'Columns', 'uv-people' ),
+                            min: 1,
+                            max: 6,
+                            value: columns,
+                            onChange: function( value ) { setAttributes( { columns: value } ); },
+                            style: { height: '40px', marginBottom: 0 }
+                        } )
+                    )
+                ),
+                createElement( 'div', useBlockProps(),
+                    createElement( ServerSideRender, {
+                        block: 'uv/all-team-grid',
+                        attributes: props.attributes,
+                        LoadingResponsePlaceholder: function() {
+                            return createElement(
+                                'p',
+                                { className: 'uv-block-placeholder' },
+                                __( 'Loading preview…', 'uv-people' )
+                            );
+                        }
+                    } )
+                )
+            );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp );

--- a/plugins/uv-people/blocks/all-team-grid/style.css
+++ b/plugins/uv-people/blocks/all-team-grid/style.css
@@ -1,0 +1,88 @@
+.uv-team-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.uv-team-grid .uv-person {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border-radius: var(--uv-radius, 8px);
+    box-shadow: 0 6px 18px rgba(0,0,0,.08);
+    padding: 1rem;
+    height: 100%;
+    border: 1px solid var(--uv-border, #ddd);
+}
+.uv-team-grid .uv-person > a {
+    display: flex;
+    align-items: flex-start;
+    gap: clamp(.5rem, 2vw, 1rem);
+    text-decoration: none;
+    color: inherit;
+}
+.uv-team-grid .uv-avatar img {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.uv-team-grid .uv-info {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.uv-team-grid .uv-info > *:empty {
+    display: none;
+}
+
+.uv-team-grid .uv-person h3 {
+    margin: .3rem 0 0;
+    color: var(--uv-purple, #7a00cc);
+    font-size: 1.25rem;
+}
+
+.uv-team-grid .uv-contact {
+    margin-top: .75rem;
+}
+.uv-team-grid .uv-contact .label {
+    font-weight: 600;
+    margin-right: .25rem;
+}
+.uv-team-grid .uv-contact a {
+    color: var(--uv-purple, #7a00cc);
+    text-decoration: none;
+}
+
+.uv-team-grid .uv-quote {
+    margin-top: 1rem;
+    background: var(--uv-yellow, #fff7b2);
+    padding: .75rem 1rem;
+    position: relative;
+}
+.uv-team-grid .uv-quote .uv-quote-icon {
+    font-size: 2rem;
+    line-height: 1;
+    margin-right: .25rem;
+}
+.uv-team-grid .uv-quote::after {
+    content: "\201D";
+    position: absolute;
+    right: .5rem;
+    bottom: .25rem;
+    font-size: 2rem;
+    line-height: 1;
+}
+
+@media (max-width: 600px) {
+    .uv-team-grid {
+        grid-template-columns: 1fr;
+    }
+    .uv-team-grid .uv-person > a {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+/* Highlight primary contacts */
+.uv-team-grid .uv-person.uv-primary-contact {
+    border: 2px solid var(--uv-purple, #7a00cc);
+}


### PR DESCRIPTION
## Summary
- duplicate team grid block as all-team-grid with only column control
- add `uv_people_all_team_grid` for a site-wide team grid sorted by rank then name
- register new block and stylesheet

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad72ccdc788328a0d091b0e83b02d9