### PR TITLE
Fix meta box screen and context

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -520,7 +520,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'show_option_none' => esc_html__('— None —', 'uv-core'),
             'option_none_value' => 0,
         ]);
-    }, 'side');
+    }, null, 'side');
 });
 
 add_action('save_post_uv_experience', function($post_id){
@@ -552,7 +552,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'echo'             => false,
         ]);
         echo str_replace('<select', '<select style="width:100%;height:8em;"', $dropdown);
-    }, 'side');
+    }, null, 'side');
 });
 
 add_action('save_post_uv_experience', function($post_id){


### PR DESCRIPTION
## Summary
- Ensure experience meta boxes specify the correct Gutenberg screen and side context

## Testing
- `npm test`
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68adb05861908328933360615948d5c4