### PR TITLE
fix: create clean zips

### DIFF
--- a/.github/workflows/package-zips.yml
+++ b/.github/workflows/package-zips.yml
@@ -17,7 +17,11 @@ jobs:
           for dir in plugins/* themes/*; do
             if [ -d "$dir" ]; then
               name="$(basename "$dir")"
-              zip -r "dist/${name}.zip" "$dir"
+              parent="$(dirname "$dir")"
+              (
+                cd "$parent"
+                zip -r "../dist/${name}.zip" "$name"
+              )
             fi
           done
       - name: Upload release assets


### PR DESCRIPTION
## Summary
- ensure GitHub release zips only contain plugin/theme directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb1a156e483288db5b17270bc4976