### PR TITLE
Specify screen for experience meta boxes

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -522,7 +522,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'show_option_none' => esc_html__('— None —', 'uv-core'),
             'option_none_value' => 0,
         ]);
-    }, null, 'side');
+    }, 'uv_experience', 'side');
 });
 
 add_action('save_post_uv_experience', function($post_id){
@@ -554,7 +554,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'echo'             => false,
         ]);
         echo str_replace('<select', '<select style="width:100%;height:8em;"', $dropdown);
-    }, null, 'side');
+    }, 'uv_experience', 'side');
 });
 
 add_action('save_post_uv_experience', function($post_id){


### PR DESCRIPTION
## Summary
- ensure experience meta boxes explicitly target the uv_experience screen

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `php -l plugins/uv-people/uv-people.php`
- `wp --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8e0d3a48328993420b923617bff