### PR TITLE
Add editor placeholders for empty block data

### DIFF
--- a/plugins/uv-core/blocks/activities/index.js
+++ b/plugins/uv-core/blocks/activities/index.js
@@ -48,6 +48,13 @@ import fetchTerms from '../utils/fetchTerms';
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-core' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No activities found.', 'uv-core' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-core/blocks/experiences/index.js
+++ b/plugins/uv-core/blocks/experiences/index.js
@@ -32,6 +32,13 @@
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-core' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No experiences found.', 'uv-core' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-core/blocks/locations-grid/index.js
+++ b/plugins/uv-core/blocks/locations-grid/index.js
@@ -38,6 +38,13 @@
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-core' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No locations found.', 'uv-core' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-core/blocks/news/index.js
+++ b/plugins/uv-core/blocks/news/index.js
@@ -48,6 +48,13 @@ import fetchTerms from '../utils/fetchTerms';
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-core' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No posts found.', 'uv-core' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-core/blocks/partners/index.js
+++ b/plugins/uv-core/blocks/partners/index.js
@@ -61,6 +61,13 @@ import fetchTerms from '../utils/fetchTerms';
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-core' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No partners found.', 'uv-core' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -247,7 +247,12 @@ add_action('edited_uv_location', function($term_id){
 function uv_core_locations_grid($atts){
     $a = shortcode_atts(['columns'=>3,'show_links'=>1], $atts);
     $terms = get_terms(['taxonomy'=>'uv_location','hide_empty'=>false]);
-    if(is_wp_error($terms) || empty($terms)) return '';
+    if(is_wp_error($terms) || empty($terms)){
+        if(is_admin() || (defined('REST_REQUEST') && REST_REQUEST)){
+            return '<div class="uv-block-placeholder">'.esc_html__('No locations found.', 'uv-core').'</div>';
+        }
+        return '';
+    }
     $cols = intval($a['columns']);
     $out = '<ul class="uv-card-list" style="grid-template-columns:repeat('.$cols.',1fr)">';
     foreach($terms as $t){
@@ -304,6 +309,10 @@ function uv_core_posts_news($atts){
             echo '<div class="uv-card-body"><h3>'.esc_html(get_the_title()).'</h3></div></a></li>';
         }
         echo '</ul>';
+    } else {
+        if(is_admin() || (defined('REST_REQUEST') && REST_REQUEST)){
+            echo '<div class="uv-block-placeholder">'.esc_html__('No posts found.', 'uv-core').'</div>';
+        }
     }
     wp_reset_postdata();
     return ob_get_clean();
@@ -332,6 +341,10 @@ function uv_core_activities($atts){
             echo '</div></a></li>';
         }
         echo '</ul>';
+    } else {
+        if(is_admin() || (defined('REST_REQUEST') && REST_REQUEST)){
+            echo '<div class="uv-block-placeholder">'.esc_html__('No activities found.', 'uv-core').'</div>';
+        }
     }
     wp_reset_postdata();
     return ob_get_clean();
@@ -353,6 +366,10 @@ function uv_core_experiences($atts){
             echo '</div></a></li>';
         }
         echo '</ul>';
+    } else {
+        if(is_admin() || (defined('REST_REQUEST') && REST_REQUEST)){
+            echo '<div class="uv-block-placeholder">'.esc_html__('No experiences found.', 'uv-core').'</div>';
+        }
     }
     wp_reset_postdata();
     return ob_get_clean();
@@ -420,6 +437,10 @@ function uv_core_partners($atts){
             echo '</a></li>';
         }
         echo '</ul>';
+    } else {
+        if(is_admin() || (defined('REST_REQUEST') && REST_REQUEST)){
+            echo '<div class="uv-block-placeholder">'.esc_html__('No partners found.', 'uv-core').'</div>';
+        }
     }
     wp_reset_postdata();
     return ob_get_clean();

--- a/plugins/uv-people/blocks/all-team-grid/index.js
+++ b/plugins/uv-people/blocks/all-team-grid/index.js
@@ -32,6 +32,13 @@
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-people' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No team members found.', 'uv-people' )
+                            );
                         }
                     } )
                 )

--- a/plugins/uv-people/blocks/team-grid/index.js
+++ b/plugins/uv-people/blocks/team-grid/index.js
@@ -48,6 +48,13 @@ import fetchTerms from '../../../uv-core/blocks/utils/fetchTerms';
                                 { className: 'uv-block-placeholder' },
                                 __( 'Loading preview…', 'uv-people' )
                             );
+                        },
+                        EmptyResponsePlaceholder: function() {
+                            return createElement(
+                                'div',
+                                { className: 'uv-block-placeholder' },
+                                __( 'No team members found.', 'uv-people' )
+                            );
                         }
                     } )
                 )


### PR DESCRIPTION
## Summary
- show editor-only placeholder messages for empty uv-core and uv-people block queries
- provide `EmptyResponsePlaceholder` in block editor scripts for consistent previews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbb9cb78c8328815e5e1885b2b36c