### PR TITLE
chore: update release notes for 0.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This repository bootstraps the **Kadence child theme** and three lightweight plu
 It’s designed for **shared hosting**, with a focus on **accessibility, performance, and translation readiness**.
 
 ## Roadmap
-- **v0.5.1:** Runtime environment checks and unique version constants.
-- **v0.5.2:** Bug fixes and maintenance release.
-- **v0.5.3:** Version bump for release.
-- **v0.5.4:** Version bump for release.
-- **v0.5.5:** Version bump for release.
-- **v1.0.0:** Fully bilingual content with streamlined deployment and contributor workflows.
+- **0.5.1:** Runtime environment checks and unique version constants.
+- **0.5.2:** Bug fixes and maintenance release.
+- **0.5.3:** Version bump for release.
+- **0.5.4:** Version bump for release.
+- **0.5.6:** Meta box context fixes, editor placeholders, and clean release packaging.
+- **1.0.0:** Fully bilingual content with streamlined deployment and contributor workflows.
 
 ## Contents
 - `themes/uv-kadence-child/` – Kadence child theme (styles, small a11y tweaks).
@@ -96,19 +96,19 @@ While deploying or migrating, enable **Maintenance** plugin (already installed),
 - Add your how-to videos/links in **Dashboard → Team Guide** widget (config in `uv-people`).
 
 ## Building ZIPs from GitHub
-Tag a release like `v0.5.5` and GitHub Actions will attach zips for the child theme and each plugin.
+Tag a release like `0.5.6` and GitHub Actions will attach zips for the child theme and each plugin.
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
 See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
 ### Tagging and making releases
 1. Commit your changes and push them to GitHub.
 2. In the repository, click **Releases** → **Draft a new release**.
-3. In **Tag version**, enter a new tag like `v0.5.5` (use `MAJOR.MINOR.PATCH` with a `v` prefix).
+3. In **Tag version**, enter a new tag like `0.5.6` (use `MAJOR.MINOR.PATCH`).
 4. Choose **Create new tag on publish**, leaving the target branch as `main`.
 5. Add a title and notes, then click **Publish release**. GitHub Actions will build ZIPs for the theme and each plugin and attach them to the release.
 6. After the workflow completes, download the ZIPs from the release page and upload them to WordPress to update.
 
-> To tag from the command line instead, run `git tag v0.5.5 && git push origin v0.5.5` before drafting the release.
+> To tag from the command line instead, run `git tag 0.5.6 && git push origin 0.5.6` before drafting the release.
 
 ---
 © 2025 Unge Vil. MIT License.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,8 +1,10 @@
 # Updating from GitHub releases
 
+*Latest release: 0.5.6 – clarifies meta box contexts, adds editor placeholders, and generates clean ZIPs.*
+
 ## 1. Get the new ZIPs
 1. Visit the repository's [Releases](https://github.com/ungevil/Unge-Vil-Website/releases) page.
-2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `v0.5.5`).
+2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `0.5.6`).
 
 ## 2. Back up the site
 1. In your hosting panel or backup plugin (e.g. UpdraftPlus), run a full backup.
@@ -21,6 +23,6 @@
 3. Click **Install Now**, choose **Replace current version** when asked, then **Activate**.
 
 ## 4. Verify versions
-1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.5.5`).
+1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.5.6`).
 2. In **Appearance → Themes**, open the child theme details and verify its version.
 3. Browse a few pages on the front‑end to confirm the site loads as expected.

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -34,6 +34,9 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.
 
 ## Changelog
+### 0.5.6
+- Specify meta box screens and contexts.
+- Add editor placeholders for empty block data.
 ### 0.5.5
 - Version bump for release.
 ### 0.5.4

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -23,6 +23,8 @@ UV Events Bridge connects Locations to The Events Calendar.
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.
 
 ## Changelog
+### 0.5.6
+- Version bump for release; no functional changes.
 ### 0.5.5
 - Version bump for release.
 ### 0.5.4

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -27,6 +27,9 @@ Primary contacts are shown first in the grid, followed by other members sorted b
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.5.6
+- Specify post type and context for the assignment meta box.
+- Add editor placeholders for empty block data.
 ### 0.5.5
 - Version bump for release.
 ### 0.5.4

--- a/themes/uv-kadence-child/readme.md
+++ b/themes/uv-kadence-child/readme.md
@@ -1,6 +1,8 @@
 Kadence child theme for Unge Vil.
 
 ## Changelog
+### 0.5.6
+- Version bump for release; no functional changes.
 ### 0.5.5
 - Version bump for release.
 ### 0.5.4


### PR DESCRIPTION
## Summary
- document 0.5.6 meta box fixes and editor placeholders
- refresh release instructions and update version references
- add changelog entries for plugins and theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbe3880048328a789a1047d5a3aab