### PR TITLE
Disable team grid links in editor

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/block.json
+++ b/plugins/uv-people/blocks/all-team-grid/block.json
@@ -11,5 +11,6 @@
     }
   },
   "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css",
   "style": "file:./style.css"
 }

--- a/plugins/uv-people/blocks/all-team-grid/editor.css
+++ b/plugins/uv-people/blocks/all-team-grid/editor.css
@@ -1,0 +1,2 @@
+.editor-styles-wrapper .uv-team-grid a { pointer-events: none; }
+


### PR DESCRIPTION
## Summary
- disable team grid anchor pointer events in block editor
- register editor stylesheet for all-team-grid block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9ad721548328999d57e44952b29b