### PR TITLE
Disable experience block links in editor

### DIFF
--- a/plugins/uv-core/blocks/experiences/block.json
+++ b/plugins/uv-core/blocks/experiences/block.json
@@ -8,5 +8,6 @@
     "count": {"type": "number", "default": 3}
   },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css"
+  "style": "file:./style.css",
+  "editorStyle": "file:./editor.css"
 }

--- a/plugins/uv-core/blocks/experiences/editor.css
+++ b/plugins/uv-core/blocks/experiences/editor.css
@@ -1,0 +1,1 @@
+.editor-styles-wrapper .uv-card-list a { pointer-events: none; }


### PR DESCRIPTION
## Summary
- add editor stylesheet to experiences block to disable card links when editing
- register the editor stylesheet in block.json so front-end links continue to work

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9b843e148328bc81b4ac3add7919