### PR TITLE
Filter team assignments without location

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -413,11 +413,18 @@ function uv_people_all_team_grid($atts){
     wp_enqueue_style('uv-all-team-grid-style', plugin_dir_url(__FILE__) . 'blocks/all-team-grid/style.css', [], UV_PEOPLE_VERSION);
     $a = shortcode_atts(['columns'=>4], $atts);
 
-    // Fetch all team assignments and collect unique user IDs
+    // Fetch all team assignments that have a location and collect unique user IDs
+    // The meta_query filters out assignments lacking a uv_location_id.
     $assignments = get_posts([
         'post_type'      => 'uv_team_assignment',
         'numberposts'    => -1,
         'fields'         => 'ids',
+        'meta_query'     => [
+            [
+                'key'     => 'uv_location_id',
+                'compare' => 'EXISTS',
+            ],
+        ],
     ]);
     $user_ids = [];
     foreach($assignments as $aid){


### PR DESCRIPTION
## Summary
- ignore team assignments lacking `uv_location_id` in all-team grid
- document purpose of location filter in query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9eb18b0083289e2331d59f02b8d1