### PR TITLE
Align UV Experience template with Kadence structure

### DIFF
--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -5,62 +5,30 @@
 
 get_header();
 
-if ( have_posts() ) :
-    ?>
-    <main id="primary" class="site-main">
-    <?php
-    while ( have_posts() ) :
-        the_post();
-        ?>
-        <article <?php post_class(); ?>>
-            <h1><?php the_title(); ?></h1>
-            <div>
-                <?php the_content(); ?>
-                <?php
-                $users = get_post_meta( get_the_ID(), 'uv_experience_users', false );
-                if ( $users && is_array( $users ) ) :
-                    ?>
-                    <div class="uv-experience-users">
-                        <?php
-                        foreach ( $users as $user_id ) :
-                            $user_id = absint( $user_id );
-                            $user    = get_user_by( 'id', $user_id );
+do_action( 'kadence_before_main_content' );
+?>
 
-                            if ( ! $user ) {
-                                continue;
-                            }
-                            ?>
-                            <a class="uv-experience-user" href="<?php echo esc_url( get_author_posts_url( $user_id ) ); ?>">
-                                <?php echo get_avatar( $user_id, 48 ); ?>
-                                <span class="uv-experience-user-name"><?php echo esc_html( $user->display_name ); ?></span>
-                            </a>
-                            <?php
-                        endforeach;
-                        ?>
-                    </div>
-                    <?php
-                endif;
-                ?>
-            </div>
-            <?php
-            $related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );
-            if ( $related ) :
-                ?>
-                <div class="uv-related-post">
-                    <h2><?php esc_html_e( 'Related Post', 'uv-kadence-child' ); ?></h2>
-                    <a href="<?php echo esc_url( get_permalink( $related ) ); ?>">
-                        <?php echo esc_html( get_the_title( $related ) ); ?>
-                    </a>
-                </div>
-                <?php
-            endif;
-            ?>
-        </article>
+<div id="primary" class="content-area">
+    <main id="main" class="site-main" role="main">
         <?php
-    endwhile;
-    ?>
+        do_action( 'kadence_before_content' );
+
+        while ( have_posts() ) :
+            the_post();
+
+            get_template_part( 'template-parts/content', 'uv_experience' );
+
+            if ( function_exists( 'kadence_display_comments' ) && kadence_display_comments() ) :
+                comments_template();
+            endif;
+        endwhile;
+
+        do_action( 'kadence_after_content' );
+        ?>
     </main>
-    <?php
-endif;
+</div>
+
+<?php
+do_action( 'kadence_after_main_content' );
 
 get_footer();

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Content template for UV Experience single posts.
+ */
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<header class="entry-header">
+<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+</header>
+
+<div class="entry-content">
+<?php the_content(); ?>
+<?php
+$users = get_post_meta( get_the_ID(), 'uv_experience_users', false );
+if ( $users && is_array( $users ) ) :
+?>
+<div class="uv-experience-users">
+<?php
+foreach ( $users as $user_id ) :
+$user_id = absint( $user_id );
+$user    = get_user_by( 'id', $user_id );
+
+if ( ! $user ) {
+continue;
+}
+?>
+<a class="uv-experience-user" href="<?php echo esc_url( get_author_posts_url( $user_id ) ); ?>">
+<?php echo get_avatar( $user_id, 48 ); ?>
+<span class="uv-experience-user-name"><?php echo esc_html( $user->display_name ); ?></span>
+</a>
+<?php
+endforeach;
+?>
+</div>
+<?php
+endif;
+?>
+</div>
+
+<?php
+$related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );
+if ( $related ) :
+?>
+<div class="uv-related-post">
+<h2><?php esc_html_e( 'Related Post', 'uv-kadence-child' ); ?></h2>
+<a href="<?php echo esc_url( get_permalink( $related ) ); ?>">
+<?php echo esc_html( get_the_title( $related ) ); ?>
+</a>
+</div>
+<?php
+endif;
+?>
+</article>


### PR DESCRIPTION
## Summary
- Refactor UV Experience single template to use Kadence hooks and wrappers
- Introduce content template part for UV Experience posts, rendering contributors and related post

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea7841c508328b56fec20be894435