### PR TITLE
Allow selecting multiple experience users

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -589,7 +589,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'class'            => 'uv-user-select',
             'echo'             => false,
         ]);
-        echo str_replace('<select', '<select style="width:100%;"', $dropdown);
+        echo str_replace('<select', '<select multiple="multiple" style="width:100%;"', $dropdown);
     }, 'uv_experience', 'side', 'high');
 });
 


### PR DESCRIPTION
## Summary
- allow selecting multiple Team Members on Experiences

## Testing
- `npm test`
- `php -r '$saved=[]; function delete_post_meta($post_id,$key){global $saved; $saved[$post_id][$key]=[];} function add_post_meta($post_id,$key,$value){global $saved; $saved[$post_id][$key][]=$value;} function current_user_can(){return true;} function check_admin_referer(){return true;} function absint($n){return abs(intval($n));} $_POST["uv_experience_users_nonce"]=1; $_POST["uv_experience_users"]= [10,20]; $user_ids=isset($_POST["uv_experience_users"])?array_filter(array_map("absint",(array)$_POST["uv_experience_users"])):[]; delete_post_meta(1,"uv_experience_users"); foreach($user_ids as $uid){ add_post_meta(1,"uv_experience_users",$uid);} var_export($saved);'`

------
https://chatgpt.com/codex/tasks/task_e_68aebd52618083288cdedf0992514b4f