### PR TITLE
feat: add select2 to related post meta box

### DIFF
--- a/plugins/uv-core/assets/admin.js
+++ b/plugins/uv-core/assets/admin.js
@@ -1,5 +1,5 @@
 jQuery(function($){
-    $('.uv-user-select').select2({
+    $('.uv-user-select, .uv-post-select').select2({
         width: '100%'
     });
 });

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -546,7 +546,7 @@ add_action('add_meta_boxes_uv_experience', function(){
             'posts_per_page' => -1,
         ]);
 
-        $dropdown  = '<select name="uv_related_post">';
+        $dropdown  = '<select name="uv_related_post" class="uv-post-select">';
         $dropdown .= '<option value="0">' . esc_html__('— None —', 'uv-core') . '</option>';
         foreach ($posts as $p) {
             $dropdown .= sprintf(


### PR DESCRIPTION
## Summary
- enhance related post meta box dropdown with uv-post-select class
- initialize select2 for uv-post-select and uv-user-select

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aebe31559c8328963125751bbe3f53