### PR TITLE
Enhance UV Experience template with team cards and related post button

### DIFF
--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -7,3 +7,24 @@
  Version: 0.5.7
  Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/themes/uv-kadence-child
 */
+
+.uv-related-post {
+    margin-top: 2rem;
+}
+
+.uv-related-post .uv-related-button {
+    display: block;
+    width: 100%;
+    text-align: center;
+    background-color: var(--uv-purple, #7a00cc);
+    color: #fff;
+    padding: 0.75rem 1rem;
+    border-radius: var(--uv-radius, 8px);
+    text-decoration: none;
+}
+
+.uv-related-post .uv-related-button:hover,
+.uv-related-post .uv-related-button:focus {
+    background-color: #5a0099;
+    color: #fff;
+}

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -5,50 +5,57 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-<header class="entry-header">
-<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-</header>
+    <div class="entry-content-wrap">
+        <header class="entry-header">
+            <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+        </header>
 
-<div class="entry-content">
-<?php the_content(); ?>
-<?php
-$users = get_post_meta( get_the_ID(), 'uv_experience_users', false );
-if ( $users && is_array( $users ) ) :
-?>
-<div class="uv-experience-users">
-<?php
-foreach ( $users as $user_id ) :
-$user_id = absint( $user_id );
-$user    = get_user_by( 'id', $user_id );
+        <div class="entry-content">
+            <?php the_content(); ?>
+            <?php
+            $users = get_post_meta( get_the_ID(), 'uv_experience_users', false );
+            if ( $users && is_array( $users ) ) :
+                wp_enqueue_style( 'uv-team-grid-style', plugins_url( 'uv-people/blocks/team-grid/style.css' ), [], defined( 'UV_PEOPLE_VERSION' ) ? UV_PEOPLE_VERSION : null );
+            ?>
+            <div class="uv-experience-users uv-team-grid" role="list">
+                <?php
+                $lang = function_exists( 'pll_current_language' ) ? pll_current_language( 'slug' ) : substr( get_locale(), 0, 2 );
+                foreach ( $users as $user_id ) :
+                    $user_id = absint( $user_id );
+                    $user    = get_user_by( 'id', $user_id );
 
-if ( ! $user ) {
-continue;
-}
-?>
-<a class="uv-experience-user" href="<?php echo esc_url( get_author_posts_url( $user_id ) ); ?>">
-<?php echo get_avatar( $user_id, 48 ); ?>
-<span class="uv-experience-user-name"><?php echo esc_html( $user->display_name ); ?></span>
-</a>
-<?php
-endforeach;
-?>
-</div>
-<?php
-endif;
-?>
-</div>
+                    if ( ! $user ) {
+                        continue;
+                    }
 
-<?php
-$related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );
-if ( $related ) :
-?>
-<div class="uv-related-post">
-<h2><?php esc_html_e( 'Related Post', 'uv-kadence-child' ); ?></h2>
-<a href="<?php echo esc_url( get_permalink( $related ) ); ?>">
-<?php echo esc_html( get_the_title( $related ) ); ?>
-</a>
-</div>
-<?php
-endif;
-?>
+                    $role_nb = get_user_meta( $user_id, 'uv_position_nb', true );
+                    $role_en = get_user_meta( $user_id, 'uv_position_en', true );
+                    $role    = ( 'en' === $lang ) ? ( $role_en ?: $role_nb ) : ( $role_nb ?: $role_en );
+                    $url     = add_query_arg( 'team', '1', get_author_posts_url( $user_id ) );
+                ?>
+                <article class="uv-person" role="listitem">
+                    <a href="<?php echo esc_url( $url ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View profile for %s', 'uv-kadence-child' ), $user->display_name ) ); ?>">
+                        <div class="uv-avatar"><?php echo get_avatar( $user_id, 96 ); ?></div>
+                        <div class="uv-info">
+                            <h3><?php echo esc_html( $user->display_name ); ?></h3>
+                            <?php if ( $role ) : ?>
+                                <div class="uv-role"><?php echo esc_html( $role ); ?></div>
+                            <?php endif; ?>
+                        </div>
+                    </a>
+                </article>
+                <?php endforeach; ?>
+            </div>
+            <?php endif; ?>
+        </div>
+
+        <?php
+        $related = absint( get_post_meta( get_the_ID(), 'uv_related_post', true ) );
+        if ( $related ) :
+        ?>
+        <div class="uv-related-post">
+            <a class="uv-related-button" href="<?php echo esc_url( get_permalink( $related ) ); ?>"><?php esc_html_e( 'Read blog post', 'uv-kadence-child' ); ?></a>
+        </div>
+        <?php endif; ?>
+    </div>
 </article>


### PR DESCRIPTION
## Summary
- wrap UV Experience content in standard theme container
- display experience users with team card markup
- add full-width purple "Read blog post" button when a related post is set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec87d1b78832882d94fe41d5c5b48