### PR TITLE
Append team query parameter to author links

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -71,6 +71,11 @@ add_action('init', function() {
     }
 });
 
+// Ensure author links point to the team view
+add_filter('author_link', function($link, $author_id, $author_nicename) {
+    return add_query_arg('team', 1, $link);
+}, 10, 3);
+
 // Use custom team author template when ?team is present on author URLs
 add_filter('author_template', function($template) {
     if (isset($_GET['team'])) {


### PR DESCRIPTION
## Summary
- Ensure all author links include `?team=1` to utilize custom team author template

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af655b6d788328afb86647edccc56e