### PR TITLE
Add location filter to All Team Grid block

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/block.json
+++ b/plugins/uv-people/blocks/all-team-grid/block.json
@@ -8,6 +8,17 @@
     "columns": {
       "type": "number",
       "default": 4
+    },
+    "locations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "allLocations": {
+      "type": "boolean",
+      "default": true
     }
   },
   "editorScript": "file:./index.js",

--- a/plugins/uv-people/blocks/all-team-grid/index.js
+++ b/plugins/uv-people/blocks/all-team-grid/index.js
@@ -1,17 +1,39 @@
+import fetchTerms from '../../../uv-core/blocks/utils/fetchTerms';
+
 ( function( wp ) {
     const { createElement } = wp.element;
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
     const { InspectorControls, useBlockProps } = wp.blockEditor;
-    const { PanelBody, RangeControl } = wp.components;
+    const { PanelBody, RangeControl, SelectControl, ToggleControl } = wp.components;
     const ServerSideRender = wp.serverSideRender;
 
     registerBlockType( 'uv/all-team-grid', {
         edit: function( props ) {
-            const { attributes: { columns }, setAttributes } = props;
+            const { attributes: { columns, locations = [], allLocations }, setAttributes } = props;
+            const query = { per_page: 100 };
+            const { terms, error } = fetchTerms( 'uv_location', query );
+            const options = terms ? terms.map( function( t ) { return { label: t.name, value: t.slug }; } ) : [];
             return createElement( wp.element.Fragment, {},
                 createElement( InspectorControls, {},
                     createElement( PanelBody, { title: __( 'Settings', 'uv-people' ), initialOpen: true },
+                        error ?
+                        createElement( 'p', { className: 'uv-block-placeholder' }, __( 'Failed to load locations.', 'uv-people' ) ) :
+                        createElement( SelectControl, {
+                            multiple: true,
+                            label: __( 'Locations', 'uv-people' ),
+                            value: locations,
+                            options: options,
+                            onChange: function( value ) { setAttributes( { locations: value } ); },
+                            disabled: allLocations,
+                            style: { minHeight: '40px', marginBottom: 0 }
+                        } ),
+                        createElement( ToggleControl, {
+                            label: __( 'All locations', 'uv-people' ),
+                            checked: allLocations,
+                            onChange: function( value ) { setAttributes( { allLocations: value } ); },
+                            style: { height: '40px', marginBottom: 0 }
+                        } ),
                         createElement( RangeControl, {
                             label: __( 'Columns', 'uv-people' ),
                             min: 1,

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -10,6 +10,9 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
   - `columns` (default: 4) number of columns in the grid.
   - `highlight_primary` (0 or 1) emphasize primary team members.
 
+## Blocks
+- **All Team Grid** – display team members across locations. In the block settings, choose one or more Locations or enable *All locations* to show everyone.
+
 ### Sorting
 Primary contacts are shown first in the grid, followed by other members sorted by their custom order weight and then alphabetically by display name.
 


### PR DESCRIPTION
## Summary
- allow All Team Grid block to filter by specific locations or show all
- expose new locations selector and All locations toggle in editor
- document All Team Grid block and its location filter

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`

------
https://chatgpt.com/codex/tasks/task_e_68b1bf6c97fc8328813d29356661bd73