### PR TITLE
Use author_name parameter for team profiles

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -375,8 +375,8 @@ function uv_people_team_grid($atts){
         // Link each card to custom team template
         $url = add_query_arg(
             [
-                'team'   => 1,
-                'author' => get_the_author_meta('user_nicename', $uid),
+                'team'        => 1,
+                'author_name' => get_the_author_meta('user_nicename', $uid),
             ],
             home_url('/')
         );
@@ -493,8 +493,8 @@ function uv_people_all_team_grid($atts){
         $classes = 'uv-person';
         $url = add_query_arg(
             [
-                'team'   => 1,
-                'author' => get_the_author_meta('user_nicename', $uid),
+                'team'        => 1,
+                'author_name' => get_the_author_meta('user_nicename', $uid),
             ],
             home_url('/')
         );

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -33,8 +33,8 @@
                     $role    = ( 'en' === $lang ) ? ( $role_en ?: $role_nb ) : ( $role_nb ?: $role_en );
                     $url     = add_query_arg(
                         [
-                            'team'   => 1,
-                            'author' => get_the_author_meta( 'user_nicename', $user_id ),
+                            'team'        => 1,
+                            'author_name' => get_the_author_meta( 'user_nicename', $user_id ),
                         ],
                         home_url( '/' )
                     );


### PR DESCRIPTION
## Summary
- build team member profile links with `author_name` so WordPress resolves author slug correctly
- update experience template to use `author_name` for linked profiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c0d219ac832893a8c951b8d89984