### PR TITLE
Add container wrapper for single experience template

### DIFF
--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -8,24 +8,26 @@ get_header();
 do_action( 'kadence_before_main_content' );
 ?>
 
-<div id="primary" class="content-area">
-    <main id="main" class="site-main" role="main">
-        <?php
-        do_action( 'kadence_before_content' );
+<div class="container">
+    <div id="primary" class="content-area">
+        <main id="main" class="site-main" role="main">
+            <?php
+            do_action( 'kadence_before_content' );
 
-        while ( have_posts() ) :
-            the_post();
+            while ( have_posts() ) :
+                the_post();
 
-            get_template_part( 'template-parts/content', 'uv_experience' );
+                get_template_part( 'template-parts/content', 'uv_experience' );
 
-            if ( function_exists( 'kadence_display_comments' ) && kadence_display_comments() ) :
-                comments_template();
-            endif;
-        endwhile;
+                if ( function_exists( 'kadence_display_comments' ) && kadence_display_comments() ) :
+                    comments_template();
+                endif;
+            endwhile;
 
-        do_action( 'kadence_after_content' );
-        ?>
-    </main>
+            do_action( 'kadence_after_content' );
+            ?>
+        </main>
+    </div>
 </div>
 
 <?php


### PR DESCRIPTION
## Summary
- wrap single experience page content in a `.container` div for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca61650c8328bca7d24bff2ca269