### PR TITLE
Display user bios in team grids

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/style.css
+++ b/plugins/uv-people/blocks/all-team-grid/style.css
@@ -34,6 +34,10 @@
     display: none;
 }
 
+.uv-team-grid .uv-bio {
+    margin-top: .75rem;
+}
+
 .uv-team-grid .uv-person h3 {
     margin: .3rem 0 0;
     color: var(--uv-purple, #7a00cc);

--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -34,6 +34,10 @@
     display: none;
 }
 
+.uv-team-grid .uv-bio {
+    margin-top: .75rem;
+}
+
 .uv-team-grid .uv-person h3 {
     margin: .3rem 0 0;
     color: var(--uv-purple, #7a00cc);

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -397,6 +397,8 @@ function uv_people_team_grid($atts){
         $quote = ($lang==='en') ? ($quote_en ?: $quote_nb) : ($quote_nb ?: $quote_en);
         echo '</div>';
         echo '</a>';
+        $bio = get_the_author_meta('description', $uid);
+        if($bio) echo '<div class="uv-bio">'.wp_kses_post(wpautop($bio)).'</div>';
         // contact visibility
         $show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
         if(($phone && $show_phone) || $email){
@@ -510,6 +512,8 @@ function uv_people_all_team_grid($atts){
         if($role) echo '<div class="uv-role">'.esc_html($role).'</div>';
         echo '</div>';
         echo '</a>';
+        $bio = get_the_author_meta('description', $uid);
+        if($bio) echo '<div class="uv-bio">'.wp_kses_post(wpautop($bio)).'</div>';
         $show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
         if(($phone && $show_phone) || $email){
             $email_label = ($lang==='en') ? __('Email:','uv-people') : __('E-post:','uv-people');


### PR DESCRIPTION
## Summary
- output author bios after each team member card in uv_people_team_grid and uv_people_all_team_grid
- add spacing styles for team-member bios in team grid styles

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`
- `php -r 'function get_the_author_meta($field,$uid){$data=[1=>["description"=>"Bio for user 1"],2=>["description"=>""]];return $data[$uid][$field];} function wpautop($t){return "<p>$t</p>";} function wp_kses_post($t){return $t;} foreach([1,2] as $uid){$bio=get_the_author_meta("description",$uid); if($bio){echo "<div class=\"uv-bio\">".wp_kses_post(wpautop($bio))."</div>\n";} else {echo "(no bio)\n";}}'`

------
https://chatgpt.com/codex/tasks/task_e_68b1cd7b0e5c8328a776f80381fe61de