### PR TITLE
Add skip link for accessibility

### DIFF
--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -40,3 +40,7 @@ body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-se
 @media (min-width:1500px){.uv-team-grid.columns-5{grid-template-columns:repeat(5,1fr)}}
 @media (min-width:1800px){.uv-team-grid.columns-6{grid-template-columns:repeat(6,1fr)}}
 .uv-team-member{max-width:800px;margin-left:auto;margin-right:auto}
+
+/* Visually hide skip link until focused */
+.skip-link{position:absolute;top:-40px;left:0;background:#000;color:#fff;padding:.5rem;z-index:100;text-decoration:none}
+.skip-link:focus{top:0}

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -48,6 +48,11 @@ add_action('after_setup_theme', function() {
     load_child_theme_textdomain('uv-kadence-child', get_stylesheet_directory() . '/languages');
 });
 
+// Accessibility: add skip link at the start of the document
+add_action('wp_body_open', function() {
+    echo '<a class="skip-link" href="#main-content">' . esc_html__('Skip to content', 'uv-kadence-child') . '</a>';
+});
+
 // Register block patterns for shortcode blocks
 add_action('init', function() {
     if (!function_exists('register_block_pattern')) {

--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -10,7 +10,7 @@ do_action( 'kadence_before_main_content' );
 
 <div class="container">
     <div id="primary" class="content-area">
-        <main id="main" class="site-main" role="main">
+        <main id="main-content" class="site-main" role="main">
             <?php
             do_action( 'kadence_before_content' );
 

--- a/themes/uv-kadence-child/taxonomy-uv_location.php
+++ b/themes/uv-kadence-child/taxonomy-uv_location.php
@@ -13,7 +13,7 @@ if ( $term && ! is_wp_error( $term ) ) {
     $slug   = $term->slug;
     $img_id = get_term_meta( $term->term_id, 'uv_location_image', true );
     ?>
-    <main id="primary" class="site-main">
+    <main id="main-content" class="site-main">
         <article class="uv-location">
             <div class="uv-card">
                 <?php if ( $img_id ) : ?>


### PR DESCRIPTION
## Summary
- Add wp_body_open hook emitting a "Skip to content" link
- Hide skip link visually until focused
- Mark main content wrappers with `id="main-content"`

## Testing
- `npm test`
- `php -l themes/uv-kadence-child/functions.php`
- `php -l themes/uv-kadence-child/single-uv_experience.php`
- `php -l themes/uv-kadence-child/taxonomy-uv_location.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1d76958e48328a0f003d59492f617