### PR TITLE
feat: add focus styles for legacy browsers

### DIFF
--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -8,7 +8,7 @@
 .uv-card a{display:block;text-decoration:none}
 .uv-card a:hover,.uv-card a:focus{text-decoration:underline}
 .uv-card .uv-card-body{padding:12px}
-.uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
+.uv-card:focus-visible,.uv-card a:focus-visible,a:focus-visible,.uv-person:focus-visible,.uv-card:focus,.uv-card a:focus,a:focus,.uv-person:focus{outline:3px solid var(--uv-purple);outline-offset:4px;transition:outline-offset .2s ease-in-out}
 .uv-primary-contact{border:2px solid var(--uv-purple);border-radius:var(--uv-radius)}
 .uv-person{background:#fff;border-radius:var(--uv-radius);box-shadow:0 6px 18px rgba(0,0,0,.08);padding:1rem;display:flex;flex-direction:column;height:100%;border:1px solid var(--uv-border,#ddd)}
 .uv-person>a{display:flex;align-items:flex-start;gap:clamp(.5rem,2vw,1rem);text-decoration:none;color:inherit}


### PR DESCRIPTION
## Summary
- ensure visible outlines for card links and persons on keyboard focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1dae89c6c8328b66b583ff5f4b458