### PR TITLE
Wrap admin control panel links in nav list

### DIFF
--- a/themes/uv-kadence-child/assets/css/control-panel.css
+++ b/themes/uv-kadence-child/assets/css/control-panel.css
@@ -49,6 +49,9 @@ body.toplevel_page_uv-control-panel h3 {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .uv-link-card {

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -223,15 +223,15 @@ function uv_render_control_panel() {
     echo '<h1>' . sprintf(esc_html__('Welcome, %s!', 'uv-kadence-child'), esc_html($display_name)) . '</h1>';
     echo '</div>';
 
-    echo '<div class="uv-links">';
+    echo '<nav><ul class="uv-links">';
     foreach ($links as $link) {
         $target = $link['target'] === '_blank' ? ' target="_blank" rel="noopener"' : '';
-        echo '<a class="uv-link-card" href="' . esc_url($link['url']) . '"' . $target . '>';
+        echo '<li><a class="uv-link-card" href="' . esc_url($link['url']) . '"' . $target . '>';
         echo '<img src="' . esc_url($img_base . '/' . $link['img']) . '" alt="" />';
         echo '<span>' . esc_html($link['label']) . '</span>';
-        echo '</a>';
+        echo '</a></li>';
     }
-    echo '</div>';
+    echo '</ul></nav>';
     echo '</div>';
 }
 


### PR DESCRIPTION
## Summary
- Wrap control panel link cards in a `<nav>` with an unordered list
- Remove default list styling so existing card layout is preserved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1db8a923c832895a1c7aa711b5cc8