### PR TITLE
Add lazy loading to avatar images

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -303,10 +303,10 @@ function uv_people_get_avatar($user_id){
     $name = get_the_author_meta('display_name', $user_id);
     $alt  = $name ? esc_attr($name) : '';
     if($id){
-        $img = wp_get_attachment_image($id, 'uv_avatar', false, ['alt'=>$alt]);
+        $img = wp_get_attachment_image($id, 'uv_avatar', false, ['alt' => $alt, 'loading' => 'lazy']);
         return $img;
     }
-    return get_avatar($user_id, 96, '', $alt); // fallback
+    return get_avatar($user_id, 96, '', $alt, ['loading' => 'lazy']); // fallback
 }
 
 // Shortcode: Team grid by location


### PR DESCRIPTION
## Summary
- use WordPress's `loading` attribute to lazily load people avatars

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`
- `npx wp-env start` *(fails: 403 Forbidden fetching wp-env package)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dcee82bc8328a958a142d402106c