### PR TITLE
Guard block pattern registration against missing files

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -66,11 +66,16 @@ add_action('init', function() {
         'team-grid'      => __('Team Grid', 'uv-kadence-child'),
     ];
     foreach ($patterns as $slug => $title) {
+        $pattern_path = get_theme_file_path('shortcode-patterns/' . $slug . '.php');
+        if (!file_exists($pattern_path)) {
+            error_log('Block pattern file not found: ' . $pattern_path);
+            continue;
+        }
         register_block_pattern(
             'uv-kadence-child/' . $slug,
             [
                 'title'   => $title,
-                'content' => include get_theme_file_path('shortcode-patterns/' . $slug . '.php'),
+                'content' => include $pattern_path,
             ]
         );
     }


### PR DESCRIPTION
## Summary
- Avoid including missing PHP files in block-pattern registration by checking with `file_exists`

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e04bc1808328882f1ab9a1266ee6