### PR TITLE
Sanitize shortcode output in location taxonomy template

### DIFF
--- a/themes/uv-kadence-child/taxonomy-uv_location.php
+++ b/themes/uv-kadence-child/taxonomy-uv_location.php
@@ -28,11 +28,11 @@ if ( $term && ! is_wp_error( $term ) ) {
             </div>
 
             <h2><?php esc_html_e( 'Team', 'uv-kadence-child' ); ?></h2>
-            <?php echo do_shortcode( '[uv_team location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo wp_kses_post( do_shortcode( '[uv_team location="' . esc_attr( $slug ) . '"]' ) ); ?>
             <h2><?php esc_html_e( 'News', 'uv-kadence-child' ); ?></h2>
-            <?php echo do_shortcode( '[uv_news location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo wp_kses_post( do_shortcode( '[uv_news location="' . esc_attr( $slug ) . '"]' ) ); ?>
             <h2><?php esc_html_e( 'Activities', 'uv-kadence-child' ); ?></h2>
-            <?php echo do_shortcode( '[uv_activities location="' . esc_attr( $slug ) . '"]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo wp_kses_post( do_shortcode( '[uv_activities location="' . esc_attr( $slug ) . '"]' ) ); ?>
         </article>
     </main>
     <?php


### PR DESCRIPTION
## Summary
- sanitize [uv_team], [uv_news], and [uv_activities] shortcodes using `wp_kses_post`
- remove PHPCS ignores around shortcode output

## Testing
- `npm test`
- `php -l themes/uv-kadence-child/taxonomy-uv_location.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e0d3580c8328adb30155acb4f340