### PR TITLE
Add excerpt support to partner card displays

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -433,11 +433,22 @@ function uv_core_partners($atts){
                     break;
                 case 'circle_title':
                     $render_thumb(['class'=>'is-circle']);
-                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div>';
+                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong>';
+                    $excerpt = get_the_excerpt();
+                    if ( $excerpt ) {
+                        echo '<div>' . esc_html( $excerpt ) . '</div>';
+                    }
+                    echo '</div>';
                     break;
                 case 'title_only':
-                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong></div>';
+                    echo '<div class="uv-card-body"><strong>'.esc_html(get_the_title()).'</strong>';
+                    $excerpt = get_the_excerpt();
+                    if ( $excerpt ) {
+                        echo '<div>' . esc_html( $excerpt ) . '</div>';
+                    }
+                    echo '</div>';
                     break;
+                case 'logo_title':
                 default:
                     $render_thumb();
                     echo '<div class="uv-card-body"><strong>' . esc_html( get_the_title() ) . '</strong>';


### PR DESCRIPTION
## Summary
- show excerpts for `circle_title` and `title_only` partner cards
- add explicit `logo_title` display mode with logo, title, and excerpt

## Testing
- `php -l plugins/uv-core/uv-core.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f0adfe1083288fb3deed5be16b07