### PR TITLE
Add spacing above team member avatars

### DIFF
--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -27,6 +27,7 @@
 .uv-person .uv-quote:after{content:"\201D";position:absolute;right:.5rem;bottom:.25rem;font-size:2rem;line-height:1}
 .uv-card-body h3{margin:0;font-size:1rem}
 .uv-member-header{display:flex;flex-direction:column;align-items:center;gap:.5rem}
+.uv-member-header .uv-avatar{margin-top:2rem}
 .uv-position{font-size:1rem;color:#555}
 .uv-articles{list-style:none;margin:0;padding:0;display:grid;gap:.5rem}
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}


### PR DESCRIPTION
## Summary
- add top margin for avatars within team member header

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f26f0b508328861b72d1b57a6221