### PR TITLE
Add translation support to experiences block

### DIFF
--- a/plugins/uv-core/blocks/experiences/block.json
+++ b/plugins/uv-core/blocks/experiences/block.json
@@ -1,9 +1,12 @@
 {
   "apiVersion": 2,
   "name": "uv/experiences",
-  "title": "Experiences",
   "category": "unge-vil",
   "icon": "admin-site",
+  "textdomain": "uv-core",
+  "__i18n__": {
+    "title": "Experiences"
+  },
   "attributes": {
     "count": {"type": "number", "default": 3}
   },

--- a/plugins/uv-core/languages/uv-core-nb_NO-610d533db7b310efc0aea5f0e336e03e.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-610d533db7b310efc0aea5f0e336e03e.json
@@ -1,0 +1,18 @@
+{
+  "translation-revision-date": "2025-08-29 00:00+0000",
+  "generator": "manual",
+  "domain": "uv-core",
+  "locale_data": {
+    "uv-core": {
+      "": {
+        "domain": "uv-core",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "Experiences": ["Erfaringer"]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-core/blocks/experiences/block.json"
+  }
+}

--- a/plugins/uv-core/languages/uv-core-nb_NO.po
+++ b/plugins/uv-core/languages/uv-core-nb_NO.po
@@ -1,0 +1,9 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: uv-core\n"
+"Language: nb_NO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: blocks/experiences/block.json
+msgid "Experiences"
+msgstr "Erfaringer"

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -665,6 +665,9 @@ add_action('init', function(){
     register_block_type(__DIR__ . '/blocks/experiences', [
         'render_callback' => 'uv_core_experiences'
     ]);
+    if (function_exists('wp_set_script_translations')) {
+        wp_set_script_translations('uv-experiences-editor-script', 'uv-core', plugin_dir_path(__FILE__) . 'languages');
+    }
     register_block_type(__DIR__ . '/blocks/activities', [
         'render_callback' => 'uv_core_activities'
     ]);


### PR DESCRIPTION
## Summary
- add `textdomain` and translation mapping for Experiences block
- load translation files on block registration
- provide nb_NO translation for block title

## Testing
- `wp i18n make-pot plugins/uv-core plugins/uv-core/languages/uv-core.pot` *(fails: command not found)*
- `wp i18n make-json plugins/uv-core/languages` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7505968832884a1c557a48c8524