### PR TITLE
Remove default list styling from card grids

### DIFF
--- a/plugins/uv-core/assets/uv-card-grid.css
+++ b/plugins/uv-core/assets/uv-card-grid.css
@@ -1,4 +1,7 @@
 .uv-card-grid {
+    margin: 0;
+    padding: 0;
+    list-style: none; /* Remove default list styling */
     display: grid;
     gap: 1.5rem;
     grid-template-columns: repeat(var(--uv-columns, 4), minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- remove margin, padding, and bullets from `.uv-card-grid` to align cards with surrounding content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2047a988c8328ae0c3f67951158c0