### PR TITLE
Use translatable contact labels

### DIFF
--- a/themes/uv-kadence-child/languages/uv-kadence-child.pot
+++ b/themes/uv-kadence-child/languages/uv-kadence-child.pot
@@ -14,3 +14,9 @@ msgstr "Artikler"
 
 msgid "Read blog post"
 msgstr "Les blogginnlegg"
+
+msgid "Email:"
+msgstr "E-post:"
+
+msgid "Mobile:"
+msgstr "Mobil:"

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -63,8 +63,8 @@
                     $show_phone = get_user_meta( $user_id, 'uv_show_phone', true ) === '1';
 
                     if ( ( $phone && $show_phone ) || $email ) :
-                        $email_label = ( 'en' === $lang ) ? __( 'Email:', 'uv-people' ) : __( 'E-post:', 'uv-people' );
-                        $phone_label = ( 'en' === $lang ) ? __( 'Mobile:', 'uv-people' ) : __( 'Mobil:', 'uv-people' );
+                        $email_label = __( 'Email:', 'uv-kadence-child' );
+                        $phone_label = __( 'Mobile:', 'uv-kadence-child' );
                     ?>
                     <div class="uv-contact">
                         <?php if ( $email ) : ?>


### PR DESCRIPTION
## Summary
- Use theme translation functions for experience contact labels
- Add Norwegian translations for new contact labels

## Testing
- `npm test`
- `npx @wordpress/wp i18n make-pot themes/uv-kadence-child themes/uv-kadence-child/languages/uv-kadence-child.pot` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b20604bce88328a2185e1cab83316f