### PR TITLE
Add textdomain for uv-core blocks and update translations

### DIFF
--- a/plugins/uv-core/blocks/activities/block.json
+++ b/plugins/uv-core/blocks/activities/block.json
@@ -4,6 +4,7 @@
   "title": "Activities",
   "category": "unge-vil",
   "icon": "admin-site",
+  "textdomain": "uv-core",
   "attributes": {
     "location": {"type": "string", "default": ""},
     "columns": {"type": "number", "default": 3}

--- a/plugins/uv-core/blocks/locations-grid/block.json
+++ b/plugins/uv-core/blocks/locations-grid/block.json
@@ -4,6 +4,7 @@
   "title": "Locations Grid",
   "category": "unge-vil",
   "icon": "location-alt",
+  "textdomain": "uv-core",
   "attributes": {
     "columns": {"type": "number", "default": 3},
     "show_links": {"type": "boolean", "default": true}

--- a/plugins/uv-core/blocks/news/block.json
+++ b/plugins/uv-core/blocks/news/block.json
@@ -4,6 +4,7 @@
   "title": "News",
   "category": "unge-vil",
   "icon": "megaphone",
+  "textdomain": "uv-core",
   "attributes": {
     "location": {"type": "string", "default": ""},
     "count": {"type": "number", "default": 3}

--- a/plugins/uv-core/blocks/partners/block.json
+++ b/plugins/uv-core/blocks/partners/block.json
@@ -4,6 +4,7 @@
   "title": "Partners",
   "category": "unge-vil",
   "icon": "heart",
+  "textdomain": "uv-core",
   "attributes": {
     "location": {"type": "string", "default": ""},
     "type": {"type": "string", "default": ""},

--- a/plugins/uv-core/languages/uv-core-nb_NO-6a9d730f1cdf39fcef379c07fe52524f.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-6a9d730f1cdf39fcef379c07fe52524f.json
@@ -9,10 +9,10 @@
         "plural-forms": "nplurals=2; plural=(n != 1);",
         "lang": "nb_NO"
       },
-      "Experiences": ["Erfaringer"]
+      "Partners": ["Partnere"]
     }
   },
   "comment": {
-    "reference": "plugins/uv-core/blocks/experiences/block.json"
+    "reference": "plugins/uv-core/blocks/partners/block.json"
   }
 }

--- a/plugins/uv-core/languages/uv-core-nb_NO-8a1a6aabb8c0b4acf3f61cfac27e1280.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-8a1a6aabb8c0b4acf3f61cfac27e1280.json
@@ -9,10 +9,10 @@
         "plural-forms": "nplurals=2; plural=(n != 1);",
         "lang": "nb_NO"
       },
-      "Experiences": ["Erfaringer"]
+      "News": ["Nyheter"]
     }
   },
   "comment": {
-    "reference": "plugins/uv-core/blocks/experiences/block.json"
+    "reference": "plugins/uv-core/blocks/news/block.json"
   }
 }

--- a/plugins/uv-core/languages/uv-core-nb_NO-e909b994b2ab642780c06dda6c188153.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-e909b994b2ab642780c06dda6c188153.json
@@ -9,10 +9,10 @@
         "plural-forms": "nplurals=2; plural=(n != 1);",
         "lang": "nb_NO"
       },
-      "Experiences": ["Erfaringer"]
+      "Activities": ["Aktiviteter"]
     }
   },
   "comment": {
-    "reference": "plugins/uv-core/blocks/experiences/block.json"
+    "reference": "plugins/uv-core/blocks/activities/block.json"
   }
 }

--- a/plugins/uv-core/languages/uv-core-nb_NO-f2cb61969ba75e0eba59372fe1d6d218.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-f2cb61969ba75e0eba59372fe1d6d218.json
@@ -9,10 +9,10 @@
         "plural-forms": "nplurals=2; plural=(n != 1);",
         "lang": "nb_NO"
       },
-      "Experiences": ["Erfaringer"]
+      "Locations Grid": ["Stedsrutenett"]
     }
   },
   "comment": {
-    "reference": "plugins/uv-core/blocks/experiences/block.json"
+    "reference": "plugins/uv-core/blocks/locations-grid/block.json"
   }
 }

--- a/plugins/uv-core/languages/uv-core-nb_NO.po
+++ b/plugins/uv-core/languages/uv-core-nb_NO.po
@@ -4,6 +4,22 @@ msgstr ""
 "Language: nb_NO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: blocks/activities/block.json
+msgid "Activities"
+msgstr "Aktiviteter"
+
+#: blocks/partners/block.json
+msgid "Partners"
+msgstr "Partnere"
+
+#: blocks/news/block.json
+msgid "News"
+msgstr "Nyheter"
+
+#: blocks/locations-grid/block.json
+msgid "Locations Grid"
+msgstr "Stedsrutenett"
+
 #: blocks/experiences/block.json
 msgid "Experiences"
 msgstr "Erfaringer"

--- a/plugins/uv-core/languages/uv-core.pot
+++ b/plugins/uv-core/languages/uv-core.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uv-core 0.6.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-25 12:31+0000\n"
-"PO-Revision-Date: 2025-08-25 12:31+0000\n"
+"POT-Creation-Date: 2025-08-29 19:58+0000\n"
+"PO-Revision-Date: 2025-08-29 19:58+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: nb\n"
@@ -60,3 +60,11 @@ msgstr "Ekstern URL"
 #: plugins/uv-core/uv-core.php:249
 msgid "Website"
 msgstr "Nettsted"
+
+#: plugins/uv-core/blocks/news/block.json
+msgid "News"
+msgstr "Nyheter"
+
+#: plugins/uv-core/blocks/locations-grid/block.json
+msgid "Locations Grid"
+msgstr "Stedsrutenett"


### PR DESCRIPTION
## Summary
- ensure all uv-core block configurations declare the `uv-core` textdomain
- regenerate translation template and JSON files for new block titles

## Testing
- `npm test`
- `wp --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b205d97134832883e0b5cc297ca33c