### PR TITLE
Add textdomain to team grid blocks and update translations

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/block.json
+++ b/plugins/uv-people/blocks/all-team-grid/block.json
@@ -4,6 +4,7 @@
   "title": "All Team Grid",
   "category": "unge-vil",
   "icon": "groups",
+  "textdomain": "uv-people",
   "attributes": {
     "columns": {
       "type": "number",

--- a/plugins/uv-people/blocks/team-grid/block.json
+++ b/plugins/uv-people/blocks/team-grid/block.json
@@ -4,6 +4,7 @@
   "title": "Team Grid",
   "category": "unge-vil",
   "icon": "groups",
+  "textdomain": "uv-people",
   "attributes": {
     "location": {
       "type": "string",

--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uv-people 0.6.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-25 12:31+0000\n"
+"POT-Creation-Date: 2025-08-29 19:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,4 +123,14 @@ msgstr ""
 
 #: plugins/uv-people/uv-people.php:224
 msgid "Add your own how-to video links here (edit uv-people plugin)."
+msgstr ""
+
+#: plugins/uv-people/blocks/all-team-grid/block.json
+msgctxt "block title"
+msgid "All Team Grid"
+msgstr ""
+
+#: plugins/uv-people/blocks/team-grid/block.json
+msgctxt "block title"
+msgid "Team Grid"
 msgstr ""


### PR DESCRIPTION
## Summary
- add `textdomain: uv-people` to team-grid block metadata
- include block title strings in uv-people translation template

## Testing
- `npm test`
- `wp i18n make-pot plugins/uv-people plugins/uv-people/languages/uv-people.pot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2060eff348328b8a4ce43d52f8065