### PR TITLE
Add script translations for team grids

### DIFF
--- a/plugins/uv-people/languages/uv-people-nb_NO-6396a1f2bcdab0818a9e67f194f72e3c.json
+++ b/plugins/uv-people/languages/uv-people-nb_NO-6396a1f2bcdab0818a9e67f194f72e3c.json
@@ -1,0 +1,24 @@
+{
+  "translation-revision-date": "2025-08-29 20:05+0000",
+  "generator": "manual",
+  "domain": "uv-people",
+  "locale_data": {
+    "uv-people": {
+      "": {
+        "domain": "uv-people",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "Settings": ["Innstillinger"],
+      "Failed to load locations.": ["Kunne ikke laste lokasjoner."],
+      "Location": ["Sted"],
+      "Select": ["Velg"],
+      "Columns": ["Kolonner"],
+      "Loading preview…": ["Laster forhåndsvisning…"],
+      "No team members found.": ["Ingen teammedlemmer funnet."]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-people/blocks/team-grid/index.js"
+  }
+}

--- a/plugins/uv-people/languages/uv-people-nb_NO-673e52240c9697e8bc0b7830945e274b.json
+++ b/plugins/uv-people/languages/uv-people-nb_NO-673e52240c9697e8bc0b7830945e274b.json
@@ -1,0 +1,24 @@
+{
+  "translation-revision-date": "2025-08-29 20:05+0000",
+  "generator": "manual",
+  "domain": "uv-people",
+  "locale_data": {
+    "uv-people": {
+      "": {
+        "domain": "uv-people",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "Settings": ["Innstillinger"],
+      "Failed to load locations.": ["Kunne ikke laste lokasjoner."],
+      "Locations": ["Lokasjoner"],
+      "All locations": ["Alle lokasjoner"],
+      "Columns": ["Kolonner"],
+      "Loading preview…": ["Laster forhåndsvisning…"],
+      "No team members found.": ["Ingen teammedlemmer funnet."]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-people/blocks/all-team-grid/index.js"
+  }
+}

--- a/plugins/uv-people/languages/uv-people-nb_NO-cf2d51850b5c63e9cebdb8ca31a8befe.json
+++ b/plugins/uv-people/languages/uv-people-nb_NO-cf2d51850b5c63e9cebdb8ca31a8befe.json
@@ -1,0 +1,18 @@
+{
+  "translation-revision-date": "2025-08-29 20:05+0000",
+  "generator": "manual",
+  "domain": "uv-people",
+  "locale_data": {
+    "uv-people": {
+      "": {
+        "domain": "uv-people",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "All Team Grid": ["Alt teamrutenett"]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-people/blocks/all-team-grid/block.json"
+  }
+}

--- a/plugins/uv-people/languages/uv-people-nb_NO-dfc6d5c19684d04451c9a09db95f2d36.json
+++ b/plugins/uv-people/languages/uv-people-nb_NO-dfc6d5c19684d04451c9a09db95f2d36.json
@@ -1,0 +1,18 @@
+{
+  "translation-revision-date": "2025-08-29 20:05+0000",
+  "generator": "manual",
+  "domain": "uv-people",
+  "locale_data": {
+    "uv-people": {
+      "": {
+        "domain": "uv-people",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "Team Grid": ["Teamrutenett"]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-people/blocks/team-grid/block.json"
+  }
+}

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -592,6 +592,8 @@ add_action('init', function(){
     register_block_type(__DIR__ . '/blocks/team-grid', [
         'render_callback' => 'uv_people_team_grid'
     ]);
+    wp_set_script_translations( 'uv-team-grid-editor-script', 'uv-people', plugin_dir_path(__FILE__) . 'languages' );
+    wp_set_script_translations( 'uv-all-team-grid-editor-script', 'uv-people', plugin_dir_path(__FILE__) . 'languages' );
     register_block_type(__DIR__ . '/blocks/all-team-grid', [
         'render_callback' => 'uv_people_all_team_grid',
         'attributes'      => [
@@ -622,6 +624,8 @@ add_action('init', function(){
             ],
         ],
     ]);
+    wp_set_script_translations( 'uv-team-grid-editor-script', 'uv-people', plugin_dir_path(__FILE__) . 'languages' );
+    wp_set_script_translations( 'uv-all-team-grid-editor-script', 'uv-people', plugin_dir_path(__FILE__) . 'languages' );
 });
 
 // Preserve team query parameter when redirecting to pretty author URLs


### PR DESCRIPTION
## Summary
- set up script translations for the Team Grid and All Team Grid blocks
- add Norwegian JSON translation files for team grid editor scripts

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2074e4cf083289f7581176c08f7f0