### PR TITLE
Load translations for partner meta

### DIFF
--- a/plugins/uv-core/languages/uv-core-nb_NO-02f6ab20f8aedbbb2f7baa9cd905f6ec.json
+++ b/plugins/uv-core/languages/uv-core-nb_NO-02f6ab20f8aedbbb2f7baa9cd905f6ec.json
@@ -1,0 +1,24 @@
+{
+  "translation-revision-date": "2025-08-29 19:58+0000",
+  "generator": "manual",
+  "domain": "uv-core",
+  "locale_data": {
+    "uv-core": {
+      "": {
+        "domain": "uv-core",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+        "lang": "nb_NO"
+      },
+      "Partner Details": ["Partnerdetaljer"],
+      "External URL": ["Ekstern URL"],
+      "Display": ["Visning"],
+      "Logo only": ["Kun logo"],
+      "Logo and title": ["Logo og tittel"],
+      "Circle & title": ["Sirkel og tittel"],
+      "Title only": ["Kun tittel"]
+    }
+  },
+  "comment": {
+    "reference": "plugins/uv-core/assets/partner-meta.js"
+  }
+}

--- a/plugins/uv-core/languages/uv-core-nb_NO.po
+++ b/plugins/uv-core/languages/uv-core-nb_NO.po
@@ -23,3 +23,31 @@ msgstr "Stedsrutenett"
 #: blocks/experiences/block.json
 msgid "Experiences"
 msgstr "Erfaringer"
+
+#: assets/partner-meta.js
+msgid "Partner Details"
+msgstr "Partnerdetaljer"
+
+#: assets/partner-meta.js
+msgid "External URL"
+msgstr "Ekstern URL"
+
+#: assets/partner-meta.js
+msgid "Display"
+msgstr "Visning"
+
+#: assets/partner-meta.js
+msgid "Logo only"
+msgstr "Kun logo"
+
+#: assets/partner-meta.js
+msgid "Logo and title"
+msgstr "Logo og tittel"
+
+#: assets/partner-meta.js
+msgid "Circle & title"
+msgstr "Sirkel og tittel"
+
+#: assets/partner-meta.js
+msgid "Title only"
+msgstr "Kun tittel"

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -555,6 +555,7 @@ add_action('enqueue_block_editor_assets', function(){
             UV_CORE_VERSION,
             true
         );
+        wp_set_script_translations('uv-partner-meta', 'uv-core', plugin_dir_path(__FILE__) . 'languages');
     }
 });
 


### PR DESCRIPTION
## Summary
- Load translations for the partner meta editor script
- Add nb_NO translations for partner meta panel strings

## Testing
- `npm test`
- `php -l plugins/uv-core/uv-core.php`


------
https://chatgpt.com/codex/tasks/task_e_68b20eefe9d48328a17888b82667537e