### PR TITLE
Highlight primary team contacts in all-team grid

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -473,10 +473,17 @@ function uv_people_all_team_grid($atts){
         'no_found_rows'  => true,
         'meta_query'     => $meta_query,
     ]);
-    $user_ids = [];
+    $user_ids    = [];
+    $primaries   = [];
     foreach($assignments as $aid){
         $uid = get_post_meta($aid, 'uv_user_id', true);
-        if($uid) $user_ids[] = intval($uid);
+        if($uid){
+            $uid = intval($uid);
+            $user_ids[] = $uid;
+            if (get_post_meta($aid, 'uv_is_primary', true) === '1') {
+                $primaries[$uid] = true;
+            }
+        }
     }
     $user_ids = array_values(array_unique($user_ids));
 
@@ -521,7 +528,11 @@ function uv_people_all_team_grid($atts){
     foreach ($paged_items as $it) {
         $uid = $it['ID'];
         if (isset($user_map[$uid])) {
-            $items[] = [ 'user' => $user_map[$uid], 'rank' => $it['rank'] ];
+            $items[] = [
+                'user'    => $user_map[$uid],
+                'rank'    => $it['rank'],
+                'primary' => !empty($primaries[$uid]),
+            ];
         }
     }
     $total_pages = ceil($total_users / $per_page);
@@ -537,6 +548,9 @@ function uv_people_all_team_grid($atts){
         $phone = get_user_meta($uid,'uv_phone',true);
         $email = $user->user_email;
         $classes = 'uv-person';
+        if (!empty($it['primary'])) {
+            $classes .= ' uv-primary-contact';
+        }
         $url = add_query_arg(
             [
                 'team'        => 1,


### PR DESCRIPTION
## Summary
- Track `uv_is_primary` for each user when collecting team assignments
- Preserve a `primary` flag in all-team grid items and add `uv-primary-contact` class
- Ensure existing CSS highlights primary contacts with a purple border

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b212988a648328bd27020622ca4418