### PR TITLE
Use assignment rank for team grid sorting

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -480,6 +480,7 @@ function uv_people_all_team_grid($atts){
             $grouped[ $uid ] = [
                 'matched' => false,
                 'primary' => false,
+                'rank'    => null,
             ];
         }
         $loc_id  = intval( get_post_meta( $aid, 'uv_location_id', true ) );
@@ -488,6 +489,13 @@ function uv_people_all_team_grid($atts){
             $grouped[ $uid ]['matched'] = true;
             if ( get_post_meta( $aid, 'uv_is_primary', true ) === '1' ) {
                 $grouped[ $uid ]['primary'] = true;
+            }
+            $arank = get_post_meta( $aid, 'uv_rank_number', true );
+            if ( $arank !== '' ) {
+                $arank = intval( $arank );
+                if ( ! isset( $grouped[ $uid ]['rank'] ) || $arank < $grouped[ $uid ]['rank'] ) {
+                    $grouped[ $uid ]['rank'] = $arank;
+                }
             }
         }
     }
@@ -504,15 +512,18 @@ function uv_people_all_team_grid($atts){
     $offset   = ($page - 1) * $per_page;
 
     $sorted = [];
-    foreach ($user_ids as $uid) {
-        $rank = get_user_meta($uid, 'uv_rank_number', true);
-        $rank = ($rank === '' ? 999 : intval($rank));
-        $name = get_the_author_meta('display_name', $uid);
+    foreach ( $user_ids as $uid ) {
+        $rank = isset( $grouped[ $uid ]['rank'] ) ? $grouped[ $uid ]['rank'] : '';
+        if ( $rank === '' || $rank === null ) {
+            $rank = get_user_meta( $uid, 'uv_rank_number', true );
+        }
+        $rank = ( $rank === '' ? 999 : intval( $rank ) );
+        $name = get_the_author_meta( 'display_name', $uid );
         $sorted[] = [
             'ID'      => $uid,
             'rank'    => $rank,
             'name'    => $name,
-            'primary' => !empty( $grouped[ $uid ]['primary'] ),
+            'primary' => ! empty( $grouped[ $uid ]['primary'] ),
         ];
     }
     usort($sorted, function($a,$b){


### PR DESCRIPTION
## Summary
- pull rank from `uv_team_assignment` meta when available
- fall back to user `uv_rank_number` when assignment rank missing
- sort team members by resolved rank before pagination

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`
- `php /tmp/rank_test.php`
- `php /tmp/rank_test2.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2141240a883289f1557cef4f7b641