### PR TITLE
style: center header block elements

### DIFF
--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -29,6 +29,7 @@
 .uv-card-body h3{margin:0;font-size:1rem}
 .uv-member-header{display:flex;flex-direction:column;align-items:center;gap:.5rem}
 .uv-member-header .uv-avatar{margin-top:2rem}
+.uv-header-block{display:flex;flex-direction:column;align-items:center}
 .uv-position{font-size:1rem;color:#555}
 .uv-articles{list-style:none;margin:0;padding:0;display:grid;gap:.5rem}
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}


### PR DESCRIPTION
## Summary
- ensure uv-header-block displays contents in a vertically stacked, centered layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d9b4d79c8328a3d5d1b265d4ee26