### PR TITLE
Add responsive team container styling

### DIFF
--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -11,7 +11,7 @@ if ($user instanceof WP_User) :
     $uid  = $user->ID;
     $lang = function_exists('pll_current_language') ? pll_current_language('slug') : substr(get_locale(), 0, 2);
     ?>
-    <div class="container">
+    <div class="uv-team-container">
         <article class="uv-team-member">
             <header class="uv-member-header">
             <div class="uv-header-block">

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -28,3 +28,9 @@
     background-color: #5a0099;
     color: #fff;
 }
+
+.uv-team-container {
+    max-width: min(800px, 100%);
+    margin: 0 auto;
+    padding: 0 clamp(1rem, 5vw, 2rem);
+}


### PR DESCRIPTION
## Summary
- use `uv-team-container` wrapper instead of generic container on author team template
- add responsive max-width and padding styles for `uv-team-container`

## Testing
- `php -l themes/uv-kadence-child/author-team.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2da3c02508328913d83438df4488c