### PR TITLE
Specify numeric comparison for experience meta query

### DIFF
--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -653,6 +653,7 @@ function uv_core_get_experiences_for_user($user_id){
             'key' => 'uv_experience_users',
             'value' => absint($user_id),
             'compare' => '=',
+            'type' => 'NUMERIC',
         ]]
     ]);
 }


### PR DESCRIPTION
## Summary
- ensure `uv_core_get_experiences_for_user` performs numeric meta comparison by specifying `'type' => 'NUMERIC'`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2dc2d947483289cb38ee791b3c004