### PR TITLE
Ensure only category managers update location primary team

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -736,6 +736,9 @@ function uv_people_save_location_primary_team($term_id){
     if (!isset($_POST['uv_location_primary_team_nonce']) || !wp_verify_nonce($_POST['uv_location_primary_team_nonce'], 'uv_location_primary_team')) {
         return;
     }
+    if ( ! current_user_can( 'manage_categories' ) ) {
+        return;
+    }
     $ids = isset($_POST['uv_primary_team']) ? array_filter(array_map('intval', (array)$_POST['uv_primary_team'])) : [];
     update_term_meta($term_id, 'uv_primary_team', $ids);
     $assignments = get_posts([


### PR DESCRIPTION
## Summary
- add `manage_categories` capability check when saving location primary team

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc60c7388328975a414502b9b6a8