### PR TITLE
Respect admin login redirect

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -125,6 +125,9 @@ add_filter('login_redirect', function($redirect_to, $request, $user) {
     if (is_wp_error($user)) {
         return $redirect_to;
     }
+    if (is_a($user, 'WP_User') && user_can($user, 'manage_options')) {
+        return $redirect_to;
+    }
     return admin_url('admin.php?page=uv-control-panel');
 }, 10, 3);
 


### PR DESCRIPTION
## Summary
- redirect admins to their intended location after login instead of always forcing the Control Panel

## Testing
- `npm test`
- `php -l themes/uv-kadence-child/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc612c448328b960969c1a6429e7