### PR TITLE
Add uv_position taxonomy for team roles

### DIFF
--- a/plugins/uv-people/assets/admin.js
+++ b/plugins/uv-people/assets/admin.js
@@ -12,4 +12,5 @@ jQuery(function($){
     });
     $('.uv-location-select').select2({width:'100%'});
     $('.uv-user-select').select2({width:'100%'});
+    $('.uv-position-select').select2({width:'100%'});
 });

--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -21,9 +21,27 @@ if ($user instanceof WP_User) :
                 <h1><?php echo esc_html($user->display_name); ?></h1>
             </div>
             <?php
-            $position_nb = get_user_meta($uid, 'uv_position_nb', true);
-            $position_en = get_user_meta($uid, 'uv_position_en', true);
-            $position    = ($lang === 'en') ? ($position_en ?: $position_nb) : ($position_nb ?: $position_en);
+            $position = '';
+            $position_term = get_user_meta($uid, 'uv_position_term', true);
+            if ($position_term) {
+                $t = get_term($position_term, 'uv_position');
+                if (!is_wp_error($t) && $t) {
+                    if (function_exists('pll_get_term') && $lang) {
+                        $tid = pll_get_term($t->term_id, $lang);
+                        if ($tid) {
+                            $t = get_term($tid, 'uv_position');
+                        }
+                    }
+                    if ($t && !is_wp_error($t)) {
+                        $position = $t->name;
+                    }
+                }
+            }
+            if (!$position) {
+                $position_nb = get_user_meta($uid, 'uv_position_nb', true);
+                $position_en = get_user_meta($uid, 'uv_position_en', true);
+                $position    = ($lang === 'en') ? ($position_en ?: $position_nb) : ($position_nb ?: $position_en);
+            }
             if ($position) {
                 echo '<div class="uv-position">' . esc_html($position) . '</div>';
             }

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -28,9 +28,27 @@
                         continue;
                     }
 
-                    $role_nb = get_user_meta( $user_id, 'uv_position_nb', true );
-                    $role_en = get_user_meta( $user_id, 'uv_position_en', true );
-                    $role    = ( 'en' === $lang ) ? ( $role_en ?: $role_nb ) : ( $role_nb ?: $role_en );
+                    $role    = '';
+                    $role_term = get_user_meta( $user_id, 'uv_position_term', true );
+                    if ( $role_term ) {
+                        $t = get_term( $role_term, 'uv_position' );
+                        if ( ! is_wp_error( $t ) && $t ) {
+                            if ( function_exists( 'pll_get_term' ) && $lang ) {
+                                $tid = pll_get_term( $t->term_id, $lang );
+                                if ( $tid ) {
+                                    $t = get_term( $tid, 'uv_position' );
+                                }
+                            }
+                            if ( $t && ! is_wp_error( $t ) ) {
+                                $role = $t->name;
+                            }
+                        }
+                    }
+                    if ( ! $role ) {
+                        $role_nb = get_user_meta( $user_id, 'uv_position_nb', true );
+                        $role_en = get_user_meta( $user_id, 'uv_position_en', true );
+                        $role    = ( 'en' === $lang ) ? ( $role_en ?: $role_nb ) : ( $role_nb ?: $role_en );
+                    }
                     $url     = add_query_arg(
                         [
                             'team'        => 1,


### PR DESCRIPTION
## Summary
- add uv_position taxonomy for reusable position terms
- switch profile and assignment screens to select uv_position terms
- show translated position labels in team grid and team templates

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`
- `php -l themes/uv-kadence-child/template-parts/content-uv_experience.php`
- `php -l themes/uv-kadence-child/author-team.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2e1ad25808328b3ba6af7b31964b5