### PR TITLE
Add sortable team member ordering and primary toggles

### DIFF
--- a/plugins/uv-people/assets/admin.js
+++ b/plugins/uv-people/assets/admin.js
@@ -13,4 +13,7 @@ jQuery(function($){
     $('.uv-location-select').select2({width:'100%'});
     $('.uv-user-select').select2({width:'100%'});
     $('.uv-position-select').select2({width:'100%'});
+    if($('#uv-member-sortable').length){
+        $('#uv-member-sortable').sortable({handle:'.uv-handle'});
+    }
 });


### PR DESCRIPTION
## Summary
- Show assigned users on location edit screen in a drag-and-drop list with primary contact checkboxes
- Save member order and primary flags to term and assignment meta
- Respect custom member order when rendering team grids

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2e5eb79608328af913f3f6fd56093