### PR TITLE
Add user profile edit shortcode

### DIFF
--- a/plugins/uv-people/assets/edit-profile.css
+++ b/plugins/uv-people/assets/edit-profile.css
@@ -1,0 +1,41 @@
+.uv-edit-profile-form {
+    max-width: 600px;
+    margin: 2rem auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.uv-edit-profile-form label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: .25rem;
+}
+.uv-edit-profile-form input[type="text"],
+.uv-edit-profile-form select,
+.uv-edit-profile-form textarea {
+    width: 100%;
+    padding: .5rem;
+    border: 1px solid var(--uv-border, #ddd);
+    border-radius: 4px;
+}
+.uv-edit-profile-form button {
+    background: var(--uv-purple, #7a00cc);
+    color: #fff;
+    border: none;
+    padding: .6rem 1.2rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.uv-edit-profile-message {
+    margin-bottom: 1rem;
+    padding: .75rem;
+    border-radius: 4px;
+}
+.uv-edit-profile-message.uv-success {
+    background: #dff0d8;
+    border: 1px solid #c3e6cb;
+}
+.uv-edit-profile-message.uv-error {
+    background: #f8d7da;
+    border: 1px solid #f5c2c7;
+}

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -9,6 +9,7 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
   - `location` (required) Location slug to filter team members.
   - `columns` (default: 4) number of columns in the grid.
   - `highlight_primary` (0 or 1) emphasize primary team members.
+- `[uv_edit_profile]` – display an editable profile form for the currently logged-in user.
 
 ## Blocks
 - **All Team Grid** – display team members across locations. In the block settings, choose one or more Locations or enable *All locations* to show everyone.


### PR DESCRIPTION
## Summary
- add `[uv_edit_profile]` shortcode allowing logged-in users to update phone, quotes, position, and avatar
- include nonce validation, feedback messaging, and reuse existing profile save handler
- style form with new `edit-profile.css` for consistent look and document shortcode usage

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e8080ae483289802a4c70f01dd31