### PR TITLE
Allow front-end editing of primary location assignments

### DIFF
--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -37,6 +37,8 @@ Team assignment lookups are cached in transients for faster rendering. Cache ent
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.6.4
+- Allow users to edit location and primary contact assignments via shortcode profile form.
 ### 0.6.3
 - Add user profile edit shortcode.
 - Introduce `uv_position` taxonomy and sortable team members.


### PR DESCRIPTION
## Summary
- add primary locations multi-select to front-end edit profile form
- save and expose location and primary location assignments in shortcode
- bump UV People plugin to 0.6.4 with changelog entry

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2f985d6cc83288ff75608f66db4ac