### PR TITLE
Skip highlighting when showing all locations

### DIFF
--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -12,10 +12,11 @@ UV People adds user profile fields, per-location assignments, and a team grid sh
 - `[uv_edit_profile]` – display an editable profile form for the currently logged-in user.
 
 ## Blocks
-- **All Team Grid** – display team members across locations. In the block settings, choose one or more Locations or enable *All locations* to show everyone.
-  - `per_page` (default: 100) number of team members per page.
-  - `page` (default: 1) which page to display. Also respects the `uv_page` query parameter.
-  - `show_nav` (0 or 1) display pagination links.
+ - **All Team Grid** – display team members across locations. In the block settings, choose one or more Locations or enable *All locations* to show everyone.
+   - Primary contacts are highlighted only when specific Locations are selected.
+   - `per_page` (default: 100) number of team members per page.
+   - `page` (default: 1) which page to display. Also respects the `uv_page` query parameter.
+   - `show_nav` (0 or 1) display pagination links.
 
 ### Sorting
 Primary contacts are shown first in the grid, followed by other members sorted by their custom order weight and then alphabetically by display name.

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -608,7 +608,7 @@ function uv_people_all_team_grid($atts){
         $phone = get_user_meta($uid,'uv_phone',true);
         $email = $user->user_email;
         $classes = 'uv-person';
-        if (!empty($it['primary'])) {
+        if (empty($a['allLocations']) && !empty($it['primary'])) {
             $classes .= ' uv-primary-contact';
         }
         $url = add_query_arg(


### PR DESCRIPTION
## Summary
- avoid adding `uv-primary-contact` class when displaying all locations in All Team Grid
- document that primary contact highlighting occurs only when filtering specific locations

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc879b9c832889ac83027548f9bc