### PR TITLE
feat: move rank sorting to position term meta

### DIFF
--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -38,6 +38,8 @@ Team assignment lookups are cached in transients for faster rendering. Cache ent
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.6.5
+- Move rank sorting to `uv_rank_weight` term meta and add WP-CLI migration.
 ### 0.6.4
 - Allow users to edit location and primary contact assignments via shortcode profile form.
 ### 0.6.3


### PR DESCRIPTION
## Summary
- add `uv_rank_weight` term meta to `uv_position` taxonomy and expose it on add/edit screens
- use `uv_rank_weight` when sorting team grids instead of per-user meta
- provide WP-CLI command to migrate `uv_rank_number` user meta into `uv_rank_weight`

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fd1c688483288836b1977a98dde2