### PR TITLE
Add pagination options to team grid shortcode

### DIFF
--- a/plugins/uv-people/blocks/team-grid/block.json
+++ b/plugins/uv-people/blocks/team-grid/block.json
@@ -13,6 +13,18 @@
     "columns": {
       "type": "number",
       "default": 4
+    },
+    "per_page": {
+      "type": "number",
+      "default": 100
+    },
+    "page": {
+      "type": "number",
+      "default": 1
+    },
+    "show_nav": {
+      "type": "boolean",
+      "default": false
     }
   },
   "editorScript": "file:./index.js",


### PR DESCRIPTION
## Summary
- Add `per_page`, `page`, and `show_nav` attributes to team grid shortcode
- Compute total pages, slice results per page, and render pagination when enabled
- Expose new shortcode attributes in `team-grid` block settings

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b30dd9ab9c832891b7212ec35dce42