### PR TITLE
Validate primary location assignments

### DIFF
--- a/plugins/uv-people/assets/admin.js
+++ b/plugins/uv-people/assets/admin.js
@@ -13,6 +13,24 @@ jQuery(function($){
     $('.uv-location-select').select2({width:'100%'});
     $('.uv-user-select').select2({width:'100%'});
     $('.uv-position-select').select2({width:'100%'});
+    var $loc = $('#uv_locations');
+    var $primary = $('#uv_primary_locations');
+    if($loc.length && $primary.length){
+        function syncPrimary(){
+            var selected = $loc.val() || [];
+            $primary.find('option').each(function(){
+                var val = $(this).val();
+                var allowed = selected.indexOf(val) !== -1;
+                $(this).prop('disabled', !allowed);
+                if(!allowed){
+                    $(this).prop('selected', false);
+                }
+            });
+            $primary.trigger('change.select2');
+        }
+        $loc.on('change', syncPrimary);
+        syncPrimary();
+    }
     if($('#uv-member-sortable').length){
         $('#uv-member-sortable').sortable({handle:'.uv-handle'});
     }


### PR DESCRIPTION
## Summary
- Ensure primary location IDs are restricted to assigned locations when saving from Team Manager
- Enforce primary location subset checks on profile save and front-end forms
- Mirror subset validation client-side for admin and front-end forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30f171b808328ac8b86f64de1cfd3