### PR TITLE
docs: add team wiki for content management

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,12 @@
+# Project Wiki
+
+This folder provides guidance for normal team members on managing the Unge Vil website.
+
+## Articles
+
+- [Logging in with Google SSO](login-google-sso.md)
+- [Editing Your Profile](editing-profile.md)
+- [Adding Articles with Locations](creating-articles-with-locations.md)
+- [Writing News Posts](writing-news-posts.md)
+
+Each article contains step-by-step instructions for typical tasks around the site.

--- a/wiki/creating-articles-with-locations.md
+++ b/wiki/creating-articles-with-locations.md
@@ -1,0 +1,11 @@
+# Adding Articles with Locations
+
+Articles can be associated with a specific location for better discovery.
+
+1. From the dashboard open **Posts → Add New**.
+2. Enter a title and body content.
+3. In the **Locations** panel choose the relevant location or create a new one.
+4. Set featured images and categories as needed.
+5. Click **Publish** when the article is ready.
+
+The article will now appear in location-based listings throughout the site.

--- a/wiki/editing-profile.md
+++ b/wiki/editing-profile.md
@@ -1,0 +1,11 @@
+# Editing Your Profile
+
+After logging in you can update personal details and preferences.
+
+1. Click your name in the top-right corner and choose **Profile**.
+2. Update your display name, biography, and contact information.
+3. Optionally upload a profile picture using the **Profile Image** section.
+4. Press **Update Profile** at the bottom of the page to save your changes.
+5. Use **Change Password** if you want to update your credentials.
+
+Changes take effect immediately across the site.

--- a/wiki/login-google-sso.md
+++ b/wiki/login-google-sso.md
@@ -1,0 +1,11 @@
+# Logging in with Google SSO
+
+Normal team members sign in through Google to access the site's dashboard.
+
+1. Navigate to the website and click **Log In**.
+2. Choose **Continue with Google**.
+3. Select the Google account provided by the organization and complete the sign-in prompt.
+4. Upon success you are redirected to your dashboard with the appropriate permissions.
+5. If the login fails, ensure you are using the approved account or contact an administrator.
+
+Logging out can be done from the top-right user menu by selecting **Log Out**.

--- a/wiki/writing-news-posts.md
+++ b/wiki/writing-news-posts.md
@@ -1,0 +1,25 @@
+# Writing News Posts
+
+News posts keep the community informed and should follow a consistent structure.
+
+## Creating a Post
+
+1. Go to **Posts → Add New** in the dashboard.
+2. Enter a concise title summarizing the news.
+3. Write the content in the editor. Use headings, lists, and quotes to improve readability.
+4. Add a featured image to draw attention on listings.
+5. Select categories and tags that describe the topic.
+6. Use the **Excerpt** field for a short summary; this appears in previews.
+
+## Scheduling and Publishing
+
+- Use the **Publish** panel to schedule a future publish date or publish immediately.
+- Preview the post before publishing to ensure formatting and links are correct.
+
+## Post-Publish Tasks
+
+1. Share the post on social media if appropriate.
+2. Monitor comments and respond when needed.
+3. Update the post if new information becomes available.
+
+By following these steps, team members can create engaging and consistent news content for the site.


### PR DESCRIPTION
## Summary
- document Google SSO login and team profile management
- add guides for location-based articles and writing news posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b316e3ba5883289f348c76d21d8448