### PR TITLE
Expose Position taxonomy in Users menu

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -78,6 +78,7 @@ add_action('init', function(){
         'hierarchical' => false,
         'show_in_rest' => true,
         'meta_box_cb'  => false,
+        'show_in_menu' => 'users.php',
     ]);
 });
 


### PR DESCRIPTION
## Summary
- show Position taxonomy under the Users admin menu

## Testing
- `npm test`
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b31b55914483288a8af3231c378721