### PR TITLE
Remove default biography field from user profiles

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -90,6 +90,20 @@ add_action('admin_enqueue_scripts', function($hook){
     }
 });
 
+function uv_people_remove_default_bio_field(){
+    ?>
+    <style>.user-description-wrap{display:none!important;}</style>
+    <script>
+    document.addEventListener('DOMContentLoaded', function(){
+        var row = document.querySelector('.user-description-wrap');
+        if (row) row.remove();
+    });
+    </script>
+    <?php
+}
+add_action('admin_head-user-edit.php', 'uv_people_remove_default_bio_field');
+add_action('admin_head-profile.php', 'uv_people_remove_default_bio_field');
+
 // Taxonomy: uv_position
 add_action('init', function(){
     register_taxonomy('uv_position', null, [


### PR DESCRIPTION
## Summary
- Hide WordPress's built-in biographical field on profile pages so only the UV People editor remains
- Ensure biography editor posts to `description` meta

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`
- `php /tmp/test_bio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b31ef295748328b2b7491bc13f7cad