### PR TITLE
Handle avatar removal across admin and team manager

### DIFF
--- a/plugins/uv-people/assets/admin.js
+++ b/plugins/uv-people/assets/admin.js
@@ -7,8 +7,15 @@ jQuery(function($){
             var att = frame.state().get('selection').first().toJSON();
             $('#uv_avatar_id').val(att.id);
             $('#uv-avatar-preview').html('<img src="'+att.url+'" style="max-width:128px;border-radius:12px;">');
+            $('#uv-avatar-remove').show();
         });
         frame.open();
+    });
+    $('#uv-avatar-remove').on('click', function(e){
+        e.preventDefault();
+        $('#uv_avatar_id').val('');
+        $('#uv-avatar-preview').html('');
+        $(this).hide();
     });
     if ($.fn.select2) {
         $('.uv-location-select').select2({width:'100%'});

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -260,6 +260,7 @@ function uv_people_profile_fields($user){
         <td>
           <input type="hidden" id="uv_avatar_id" name="uv_avatar_id" value="<?php echo esc_attr($avatar_id); ?>">
           <button type="button" class="button" id="uv-avatar-upload"><?php esc_html_e('Select Image','uv-people'); ?></button>
+          <button type="button" class="button" id="uv-avatar-remove"<?php echo $avatar_id ? '' : ' style="display:none;"'; ?>><?php esc_html_e('Remove','uv-people'); ?></button>
           <div id="uv-avatar-preview"><?php echo $avatar_id ? wp_get_attachment_image($avatar_id,'uv_avatar') : ''; ?></div>
           <p class="description"><?php esc_html_e('This replaces Gravatar and uses a local image.','uv-people'); ?></p>
         </td></tr>
@@ -280,7 +281,14 @@ function uv_people_profile_save($user_id){
     if(isset($_POST['uv_position_term'])) update_user_meta($user_id, 'uv_position_term', absint($_POST['uv_position_term']));
     if(isset($_POST['uv_quote_nb'])) update_user_meta($user_id, 'uv_quote_nb', sanitize_textarea_field($_POST['uv_quote_nb']));
     if(isset($_POST['uv_quote_en'])) update_user_meta($user_id, 'uv_quote_en', sanitize_textarea_field($_POST['uv_quote_en']));
-    if(isset($_POST['uv_avatar_id'])) update_user_meta($user_id, 'uv_avatar_id', absint($_POST['uv_avatar_id']));
+    if(isset($_POST['uv_avatar_id'])) {
+        $avatar_id = absint($_POST['uv_avatar_id']);
+        if($avatar_id){
+            update_user_meta($user_id, 'uv_avatar_id', $avatar_id);
+        } else {
+            delete_user_meta($user_id, 'uv_avatar_id');
+        }
+    }
     if(isset($_POST['uv_birthdate'])){
         $bd = sanitize_text_field($_POST['uv_birthdate']);
         if($bd){

--- a/themes/uv-kadence-child/uv-team-manager.php
+++ b/themes/uv-kadence-child/uv-team-manager.php
@@ -188,7 +188,12 @@ function uv_team_manager_save_handler() {
             update_user_meta($uid, 'uv_position_term', absint($fields['position']));
         }
         if (isset($fields['avatar_id'])) {
-            update_user_meta($uid, 'uv_avatar_id', absint($fields['avatar_id']));
+            $avatar_id = absint($fields['avatar_id']);
+            if ($avatar_id) {
+                update_user_meta($uid, 'uv_avatar_id', $avatar_id);
+            } else {
+                delete_user_meta($uid, 'uv_avatar_id');
+            }
         }
         $loc_ids = array_map('intval', isset($fields['locations']) ? (array)$fields['locations'] : []);
         update_user_meta($uid, 'uv_location_terms', $loc_ids);


### PR DESCRIPTION
## Summary
- Delete avatar user meta when avatar ID is empty in profile save handlers
- Add removable avatar control to user profile admin page
- Show/hide avatar Remove button based on presence of image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b324f6217883289671693f3b8690ad