### PR TITLE
Use localized strings in team manager media frame

### DIFF
--- a/themes/uv-kadence-child/uv-team-manager.js
+++ b/themes/uv-kadence-child/uv-team-manager.js
@@ -28,11 +28,14 @@ jQuery(function($){
         if (!wp || !wp.media) {
             return;
         }
+        if (typeof UVTeamManager === "undefined") {
+            return;
+        }
         var $wrap = $(this).closest(".uv-avatar-field");
         var frame = wp.media({
-            title: (window.UVTeamManager && UVTeamManager.selectAvatar) || "Select Avatar",
+            title: UVTeamManager.selectAvatar,
             library: { type: "image" },
-            button: { text: (window.UVTeamManager && UVTeamManager.useImage) || "Use this image" },
+            button: { text: UVTeamManager.useImage },
             multiple: false
         });
         frame.on("select", function(){


### PR DESCRIPTION
## Summary
- Ensure team manager avatar selector uses localized strings for media frame title and button text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b327a232848328836d1b5930b4e18a