### PR TITLE
Handle empty team location metadata

### DIFF
--- a/themes/uv-kadence-child/uv-team-manager.php
+++ b/themes/uv-kadence-child/uv-team-manager.php
@@ -196,12 +196,16 @@ function uv_team_manager_save_handler() {
             }
         }
         $loc_ids = array_map('intval', isset($fields['locations']) ? (array)$fields['locations'] : []);
-        update_user_meta($uid, 'uv_location_terms', $loc_ids);
+        if (!empty($loc_ids)) {
+            update_user_meta($uid, 'uv_location_terms', $loc_ids);
+        } else {
+            delete_user_meta($uid, 'uv_location_terms');
+        }
 
         $primary_raw = array_map('intval', isset($fields['primary_locations']) ? (array)$fields['primary_locations'] : []);
-        $primary = array_values(array_intersect($primary_raw, $loc_ids));
-        if (!empty($primary)) {
-            update_user_meta($uid, 'uv_primary_locations', $primary);
+        $primary_ids = array_values(array_intersect($primary_raw, $loc_ids));
+        if (!empty($primary_ids)) {
+            update_user_meta($uid, 'uv_primary_locations', $primary_ids);
         } else {
             delete_user_meta($uid, 'uv_primary_locations');
         }


### PR DESCRIPTION
## Summary
- Remove empty `uv_location_terms` metadata and mirror logic for primary locations
- Ensure team grid queries ignore users lacking any location assignments

## Testing
- `php -l themes/uv-kadence-child/uv-team-manager.php`
- `npm test`
- `php -r '$meta=[1=>["uv_location_terms"=>[1]],2=>["uv_location_terms"=>[]],3=>[]];function team_members($meta){return array_keys(array_filter($meta,function($m){return array_key_exists("uv_location_terms",$m)||array_key_exists("uv_primary_locations",$m);}));}print_r(team_members($meta));unset($meta[2]["uv_location_terms"]);print_r(team_members($meta));'`

------
https://chatgpt.com/codex/tasks/task_e_68b32a504db08328bdaf620d5a2e6634