### PR TITLE
Unslash team manager fields before sanitization

### DIFF
--- a/themes/uv-kadence-child/uv-team-manager.php
+++ b/themes/uv-kadence-child/uv-team-manager.php
@@ -181,6 +181,7 @@ function uv_team_manager_save_handler() {
         if ($uid <= 0 || !current_user_can('edit_user', $uid)) {
             continue;
         }
+        $fields = wp_unslash($fields);
         if (isset($fields['phone'])) {
             update_user_meta($uid, 'uv_phone', sanitize_text_field($fields['phone']));
         }


### PR DESCRIPTION
## Summary
- remove slashes from posted team manager fields using `wp_unslash` before individual sanitization

## Testing
- `npm test`
- `php <<'PHP'
<?php
function wp_unslash($value) {
    return is_array($value) ? array_map('wp_unslash', $value) : stripslashes($value);
}
$fields = ['name' => "O\\'Connor"];
$fields = wp_unslash($fields);
echo $fields['name'], "\n";
PHP`

------
https://chatgpt.com/codex/tasks/task_e_68b32e3eff8883289a26b96ff48dcded