### PR TITLE
Handle missing UVTeamManager localization for avatar modal

### DIFF
--- a/themes/uv-kadence-child/uv-team-manager.js
+++ b/themes/uv-kadence-child/uv-team-manager.js
@@ -28,14 +28,15 @@ jQuery(function($){
         if (!wp || !wp.media) {
             return;
         }
-        if (typeof UVTeamManager === "undefined") {
-            return;
-        }
+        var strings = typeof UVTeamManager !== "undefined" ? UVTeamManager : {
+            selectAvatar: "Select Avatar",
+            useImage: "Use this image"
+        };
         var $wrap = $(this).closest(".uv-avatar-field");
         var frame = wp.media({
-            title: UVTeamManager.selectAvatar,
+            title: strings.selectAvatar,
             library: { type: "image" },
-            button: { text: UVTeamManager.useImage },
+            button: { text: strings.useImage },
             multiple: false
         });
         frame.on("select", function(){


### PR DESCRIPTION
## Summary
- open avatar media modal even when `UVTeamManager` localization is missing
- provide default strings for modal title and button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33a0445e88328a6f2b70c2447500d