### PR TITLE
Expose uv_position taxonomy in Control Panel

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -114,7 +114,15 @@ add_action('init', function(){
         'hierarchical' => false,
         'show_in_rest' => true,
         'meta_box_cb'  => false,
-        'show_in_menu' => 'users.php',
+        // Place the taxonomy under the UV Control Panel so non-admins can reach it
+        'show_in_menu' => 'uv-control-panel',
+        // Ensure editors can manage and assign terms
+        'capabilities' => [
+            'manage_terms' => 'manage_categories',
+            'edit_terms'   => 'manage_categories',
+            'delete_terms' => 'manage_categories',
+            'assign_terms' => 'edit_posts',
+        ],
     ]);
 });
 


### PR DESCRIPTION
## Summary
- Move `uv_position` taxonomy menu from Users to UV Control Panel
- Explicitly set capabilities so editors can manage and assign positions

## Testing
- `php -l plugins/uv-people/uv-people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b33a872f808328a3f229b39fb677b5