### PR TITLE
Match serialized integer IDs in team grid query

### DIFF
--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -786,12 +786,12 @@ function uv_people_all_team_grid($atts){
         foreach ($location_ids as $loc_id) {
             $meta_query[] = [
                 'key'     => 'uv_location_terms',
-                'value'   => '"' . $loc_id . '"',
+                'value'   => 'i:' . $loc_id . ';',
                 'compare' => 'LIKE',
             ];
             $meta_query[] = [
                 'key'     => 'uv_primary_locations',
-                'value'   => '"' . $loc_id . '"',
+                'value'   => 'i:' . $loc_id . ';',
                 'compare' => 'LIKE',
             ];
         }


### PR DESCRIPTION
## Summary
- match serialized integer IDs in `uv_people_all_team_grid` meta query so location filters work with integer arrays

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33c30a4bc8328a9fb70afbf446dde