### PR TITLE
Add external link support for Experiences

### DIFF
--- a/docs/EXPERIENCES.md
+++ b/docs/EXPERIENCES.md
@@ -9,5 +9,8 @@
 ## Linking to a Blog Post
 When editing an Experience, use the **Related Post** meta box in the sidebar to choose an existing blog post. Select **— None —** if no blog post should be connected.
 
+## Linking to an External Website
+Use the **External URL** meta box to provide a link to an outside website. If filled in, the Experience will display a “Visit website” button beneath the content and team members.
+
 ## Linking to a WordPress User
 Use the **Team Members** meta box (`uv_experience_users`) to associate one or more WordPress users with an Experience. Start typing in the selector to search and choose people; multiple users can be selected. On the front end, the selected users appear beneath the Experience content with their profile details. Team visibility is managed separately through User → Location assignments.

--- a/plugins/uv-core/includes/meta-boxes.php
+++ b/plugins/uv-core/includes/meta-boxes.php
@@ -199,6 +199,27 @@ add_action('save_post_uv_partner', function($post_id){
     }
 }, 10, 1);
 
+// External URL meta box
+add_action('add_meta_boxes_uv_experience', function(){
+    add_meta_box('uv_external_url', esc_html__('External URL', 'uv-core'), function($post){
+        $val = get_post_meta($post->ID, 'uv_external_url', true);
+        wp_nonce_field('uv_external_url_action', 'uv_external_url_nonce');
+        echo '<p><label class="screen-reader-text" for="uv_external_url">' . esc_html__('External URL', 'uv-core') . '</label>';
+        echo '<input type="url" id="uv_external_url" style="width:100%" name="uv_external_url" value="' . esc_attr($val) . '"></p>';
+    }, 'uv_experience', 'side', 'high');
+});
+add_action('save_post_uv_experience', function($post_id){
+    if(!isset($_POST['uv_external_url_nonce'])) return;
+    if(!current_user_can('edit_post', $post_id)) return;
+    check_admin_referer('uv_external_url_action', 'uv_external_url_nonce');
+    $url = isset($_POST['uv_external_url']) ? esc_url_raw($_POST['uv_external_url']) : '';
+    if($url){
+        update_post_meta($post_id, 'uv_external_url', $url);
+    }else{
+        delete_post_meta($post_id, 'uv_external_url');
+    }
+}, 10, 1);
+
 // Related post meta box
 add_action('add_meta_boxes_uv_experience', function(){
     add_meta_box('uv_related_post', esc_html__('Relatert innlegg','uv-core'), function($post){
@@ -266,6 +287,13 @@ add_action('save_post_uv_experience', function($post_id){
 }, 10, 1);
 
 add_action('init', function(){
+    register_post_meta('uv_experience', 'uv_external_url', [
+        'single' => true,
+        'type' => 'string',
+        'show_in_rest' => true,
+        'sanitize_callback' => 'esc_url_raw',
+        'auth_callback' => function(){ return current_user_can('edit_posts'); },
+    ]);
     register_post_meta('uv_experience', 'uv_related_post', [
         'single' => true,
         'type' => 'integer',

--- a/plugins/uv-core/languages/uv-core-nb_NO.po
+++ b/plugins/uv-core/languages/uv-core-nb_NO.po
@@ -28,7 +28,7 @@ msgstr "Erfaringer"
 msgid "Partner Details"
 msgstr "Partnerdetaljer"
 
-#: assets/partner-meta.js
+#: assets/partner-meta.js includes/meta-boxes.php
 msgid "External URL"
 msgstr "Ekstern URL"
 
@@ -51,3 +51,7 @@ msgstr "Sirkel og tittel"
 #: assets/partner-meta.js
 msgid "Title only"
 msgstr "Kun tittel"
+
+#: themes/uv-kadence-child/template-parts/content-uv_experience.php
+msgid "Visit website"
+msgstr "Besøk nettside"

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -105,6 +105,16 @@
                 <?php endforeach; ?>
             </div>
             <?php endif; ?>
+            <?php
+            $external_url = get_post_meta( get_the_ID(), 'uv_external_url', true );
+            if ( $external_url ) :
+            ?>
+            <div class="uv-external-link">
+                <a class="uv-related-button" href="<?php echo esc_url( $external_url ); ?>" target="_blank" rel="noopener">
+                    <?php esc_html_e( 'Visit website', 'uv-core' ); ?>
+                </a>
+            </div>
+            <?php endif; ?>
         </div>
 
         <?php


### PR DESCRIPTION
## Summary
- add `uv_external_url` meta box and register it for REST
- show “Visit website” button on Experience pages when an external URL is provided
- document external link usage and update Norwegian translations

## Testing
- `php -l plugins/uv-core/includes/meta-boxes.php`
- `php -l themes/uv-kadence-child/template-parts/content-uv_experience.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b424457b1c832897865925f4e42e54