### PR TITLE
Add partner associations to Experiences

### DIFF
--- a/docs/EXPERIENCES.md
+++ b/docs/EXPERIENCES.md
@@ -14,3 +14,6 @@ Use the **External URL** meta box to provide a link to an outside website. If fi
 
 ## Linking to a WordPress User
 Use the **Team Members** meta box (`uv_experience_users`) to associate one or more WordPress users with an Experience. Start typing in the selector to search and choose people; multiple users can be selected. On the front end, the selected users appear beneath the Experience content with their profile details. Team visibility is managed separately through User → Location assignments.
+
+## Attaching Partners
+Use the **Partners** meta box to associate one or more partner posts with the Experience. Begin typing in the selector to search for partners and select as many as needed. The chosen partners will be displayed after the team members on the front end.

--- a/plugins/uv-core/languages/uv-core-nb_NO.po
+++ b/plugins/uv-core/languages/uv-core-nb_NO.po
@@ -8,7 +8,7 @@ msgstr ""
 msgid "Activities"
 msgstr "Aktiviteter"
 
-#: blocks/partners/block.json
+#: blocks/partners/block.json includes/meta-boxes.php themes/uv-kadence-child/template-parts/content-uv_experience.php
 msgid "Partners"
 msgstr "Partnere"
 

--- a/themes/uv-kadence-child/template-parts/content-uv_experience.php
+++ b/themes/uv-kadence-child/template-parts/content-uv_experience.php
@@ -106,6 +106,90 @@
             </div>
             <?php endif; ?>
             <?php
+            $partners = get_post_meta( get_the_ID(), 'uv_experience_partners', false );
+            if ( $partners ) :
+                if ( function_exists( 'uv_core_enqueue_card_grid_style' ) ) {
+                    uv_core_enqueue_card_grid_style();
+                }
+                $partner_query = new WP_Query(
+                    [
+                        'post_type'      => 'uv_partner',
+                        'post__in'       => array_map( 'absint', $partners ),
+                        'posts_per_page' => -1,
+                        'orderby'        => 'post__in',
+                    ]
+                );
+                if ( $partner_query->have_posts() ) :
+            ?>
+            <h2><?php esc_html_e( 'Partners', 'uv-core' ); ?></h2>
+            <ul class="uv-card-list uv-card-grid">
+                <?php
+                while ( $partner_query->have_posts() ) :
+                    $partner_query->the_post();
+                    $link    = get_post_meta( get_the_ID(), 'uv_partner_url', true );
+                    $display = get_post_meta( get_the_ID(), 'uv_partner_display', true );
+                    if ( ! $display ) {
+                        $display = has_post_thumbnail() ? 'circle_title' : 'title_only';
+                    }
+                    if ( ! has_post_thumbnail() ) {
+                        $display = 'title_only';
+                    }
+                    $classes = 'uv-card uv-partner uv-partner--' . esc_attr( $display );
+                    echo '<li class="' . $classes . '">';
+                    echo $link
+                        ? '<a href="' . esc_url( $link ) . '" target="_blank" rel="noopener nofollow">'
+                        : '<a href="' . esc_url( get_permalink() ) . '" rel="noopener">';
+                    $fallback     = '<span class="uv-partner-icon"></span>';
+                    $render_thumb = function( $attrs = [] ) use ( $fallback ) {
+                        if ( has_post_thumbnail() ) {
+                            $attrs = wp_parse_args( $attrs, [ 'alt' => esc_attr( get_the_title() ) ] );
+                            the_post_thumbnail( 'uv_card', $attrs );
+                        } else {
+                            echo $fallback;
+                        }
+                    };
+                    switch ( $display ) {
+                        case 'logo_only':
+                            $render_thumb();
+                            break;
+                        case 'circle_title':
+                            $render_thumb( [ 'class' => 'is-circle' ] );
+                            echo '<div class="uv-card-body"><strong>' . esc_html( get_the_title() ) . '</strong>';
+                            $excerpt = get_the_excerpt();
+                            if ( $excerpt ) {
+                                echo '<div>' . esc_html( $excerpt ) . '</div>';
+                            }
+                            echo '</div>';
+                            break;
+                        case 'title_only':
+                            echo '<div class="uv-card-body"><strong>' . esc_html( get_the_title() ) . '</strong>';
+                            $excerpt = get_the_excerpt();
+                            if ( $excerpt ) {
+                                echo '<div>' . esc_html( $excerpt ) . '</div>';
+                            }
+                            echo '</div>';
+                            break;
+                        case 'logo_title':
+                        default:
+                            $render_thumb();
+                            echo '<div class="uv-card-body"><strong>' . esc_html( get_the_title() ) . '</strong>';
+                            $excerpt = get_the_excerpt();
+                            if ( $excerpt ) {
+                                echo '<div>' . esc_html( $excerpt ) . '</div>';
+                            }
+                            echo '</div>';
+                            break;
+                    }
+                    echo '</a></li>';
+                endwhile;
+                wp_reset_postdata();
+                ?>
+            </ul>
+            <?php
+                endif;
+            endif;
+            ?>
+            <?php
             $external_url = get_post_meta( get_the_ID(), 'uv_external_url', true );
             if ( $external_url ) :
             ?>


### PR DESCRIPTION
## Summary
- add Select2-driven meta box to relate partners with Experiences
- expose experience partners via REST and render them on single template
- document attaching partners in Experiences and update translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4259b318c8328a221e65c8107fbe1