### PR TITLE
Add age classification pill for leaders

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/style.css
+++ b/plugins/uv-people/blocks/all-team-grid/style.css
@@ -76,6 +76,16 @@
     line-height: 1;
 }
 
+.uv-age-pill {
+    display: inline-block;
+    background: var(--uv-pink, #ad1457);
+    color: #fff;
+    border-radius: 999px;
+    padding: .25rem .5rem;
+    margin: .25rem .25rem 0 0;
+    font-size: .875rem;
+}
+
 @media (max-width: 600px) {
     .uv-team-grid {
         grid-template-columns: 1fr;

--- a/plugins/uv-people/blocks/team-grid/block.json
+++ b/plugins/uv-people/blocks/team-grid/block.json
@@ -25,6 +25,10 @@
     "show_nav": {
       "type": "boolean",
       "default": false
+    },
+    "showAge": {
+      "type": "boolean",
+      "default": false
     }
   },
   "editorScript": "file:./index.js",

--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -76,6 +76,16 @@
     line-height: 1;
 }
 
+.uv-age-pill {
+    display: inline-block;
+    background: var(--uv-pink, #ad1457);
+    color: #fff;
+    border-radius: 999px;
+    padding: .25rem .5rem;
+    margin: .25rem .25rem 0 0;
+    font-size: .875rem;
+}
+
 @media (max-width: 600px) {
     .uv-team-grid {
         grid-template-columns: 1fr;

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -547,6 +547,7 @@ function uv_people_team_grid($atts){
         'per_page'          => 100,
         'page'              => 1,
         'show_nav'          => false,
+        'show_age'          => false,
     ], $atts);
     $placeholder = function($msg){
         return (is_admin() || (defined('REST_REQUEST') && REST_REQUEST))
@@ -664,6 +665,17 @@ function uv_people_team_grid($atts){
         echo '<div class="uv-avatar">'.uv_people_get_avatar($uid).'</div>';
         echo '<div class="uv-info">';
         echo '<h3>'.esc_html($name).'</h3>';
+        if($a['show_age']){
+            $birthdate = get_user_meta($uid,'uv_birthdate',true);
+            if($birthdate){
+                $bd = DateTime::createFromFormat('Y-m-d',$birthdate);
+                if($bd){
+                    $age = (new DateTime())->diff($bd)->y;
+                    $label = ($age >= 30) ? esc_html__('Voksen leder','uv-people') : esc_html__('Ung leder','uv-people');
+                    echo '<span class="uv-age-pill">'.esc_html($label).'</span>';
+                }
+            }
+        }
         $role = '';
         $role_term = $it['role_term'];
         if(!$role_term){
@@ -939,7 +951,8 @@ function uv_people_all_team_grid($atts){
                 $bd = DateTime::createFromFormat('Y-m-d', $birthdate);
                 if($bd){
                     $age = (new DateTime())->diff($bd)->y;
-                    echo '<div class="uv-age">'.sprintf(esc_html__('Alder: %d','uv-people'), $age).'</div>';
+                    $label = ($age >= 30) ? esc_html__('Voksen leder','uv-people') : esc_html__('Ung leder','uv-people');
+                    echo '<span class="uv-age-pill">'.esc_html($label).'</span>';
                 }
             }
         }

--- a/themes/uv-kadence-child/assets/css/control-panel.css
+++ b/themes/uv-kadence-child/assets/css/control-panel.css
@@ -5,6 +5,7 @@
 :root {
   --uv-purple: #7a00cc;
   --uv-radius: 16px;
+  --uv-pink: #ad1457;
   --uv-avatar-size: 96px;
 }
 
@@ -63,6 +64,15 @@ body.toplevel_page_uv-control-panel h3 {
 .uv-location-pill {
   display: inline-block;
   background: var(--uv-purple);
+  color: #fff;
+  border-radius: 999px;
+  padding: .25rem .5rem;
+  margin: .25rem .25rem 0 0;
+  font-size: .875rem;
+}
+.uv-age-pill {
+  display: inline-block;
+  background: var(--uv-pink);
   color: #fff;
   border-radius: 999px;
   padding: .25rem .5rem;

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -2,6 +2,7 @@
   --uv-purple:#7a00cc;
   --uv-radius:16px;
   --uv-yellow:#fff7b2;
+  --uv-pink:#ad1457;
   --uv-avatar-size:140px;
 }
 .uv-card-list{list-style:none;display:grid;gap:1rem;padding:0}
@@ -32,6 +33,7 @@
 .uv-header-block{display:flex;flex-direction:column;align-items:center}
 .uv-position{font-size:1rem;color:#555}
 .uv-location-pill{display:inline-block;background:var(--uv-purple);color:#fff;border-radius:999px;padding:.25rem .5rem;margin:.25rem .25rem 0 0;font-size:.875rem}
+.uv-age-pill{display:inline-block;background:var(--uv-pink);color:#fff;border-radius:999px;padding:.25rem .5rem;margin:.25rem .25rem 0 0;font-size:.875rem}
 .uv-articles{list-style:none;margin:0;padding:0;display:grid;gap:.5rem}
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}
 .uv-partner img{display:block;width:100%;height:auto;object-fit:contain}

--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -79,19 +79,36 @@ if ($user instanceof WP_User) :
         </header>
         <?php
         $locations = get_user_meta($uid, 'uv_location_terms', true);
-        if (is_array($locations) && $locations) {
+        $birthdate = get_user_meta($uid, 'uv_birthdate', true);
+        $age_pill = '';
+        if ($birthdate) {
+            $bd = DateTime::createFromFormat('Y-m-d', $birthdate);
+            if ($bd) {
+                $age  = (new DateTime())->diff($bd)->y;
+                $text = ($age >= 30)
+                    ? esc_html__('Voksen leder', 'uv-kadence-child')
+                    : esc_html__('Ung leder', 'uv-kadence-child');
+                $age_pill = '<span class="uv-age-pill">' . $text . '</span>';
+            }
+        }
+        if ($age_pill || (is_array($locations) && $locations)) {
             echo '<div class="uv-locations">';
-            foreach ($locations as $loc_id) {
-                $loc_term = get_term($loc_id, 'uv_location');
-                if (!is_wp_error($loc_term) && $loc_term) {
-                    if (function_exists('pll_get_term') && $lang) {
-                        $tid = pll_get_term($loc_term->term_id, $lang);
-                        if ($tid) {
-                            $loc_term = get_term($tid, 'uv_location');
+            if ($age_pill) {
+                echo $age_pill;
+            }
+            if (is_array($locations) && $locations) {
+                foreach ($locations as $loc_id) {
+                    $loc_term = get_term($loc_id, 'uv_location');
+                    if (!is_wp_error($loc_term) && $loc_term) {
+                        if (function_exists('pll_get_term') && $lang) {
+                            $tid = pll_get_term($loc_term->term_id, $lang);
+                            if ($tid) {
+                                $loc_term = get_term($tid, 'uv_location');
+                            }
                         }
-                    }
-                    if ($loc_term && !is_wp_error($loc_term)) {
-                        echo '<span class="uv-location-pill">' . esc_html($loc_term->name) . '</span>';
+                        if ($loc_term && !is_wp_error($loc_term)) {
+                            echo '<span class="uv-location-pill">' . esc_html($loc_term->name) . '</span>';
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add global pink age pill style for 'Ung leder' and 'Voksen leder'
- show age-based pill on user profile pages
- optional age classification pill toggle for team grid blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42d6860148328bb9d4c8d1b8f1922