### PR TITLE
chore: bump versions for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It’s designed for **shared hosting**, with a focus on **accessibility, perform
 - **0.6.4:** Team grid enhancements and profile quote controls.
 - **0.6.5:** Version bump for release.
 - **0.6.6:** Version bump for release.
+- **0.6.7:** Version bump for release.
 - **1.0.0:** Fully bilingual content with streamlined deployment and contributor workflows.
 
 ## Contents
@@ -107,19 +108,19 @@ While deploying or migrating, enable **Maintenance** plugin (already installed),
 - Add your how-to videos/links in **Dashboard → Team Guide** widget (config in `uv-people`).
 
 ## Building ZIPs from GitHub
-Tag a release like `0.6.6` and GitHub Actions will attach zips for the child theme and each plugin.
+Tag a release like `0.6.7` and GitHub Actions will attach zips for the child theme and each plugin.
 On shared hosting, download the zips from the release and install via **Plugins → Add New → Upload**.
 See [docs/UPDATING.md](docs/UPDATING.md) for step-by-step update instructions.
 
 ### Tagging and making releases
 1. Commit your changes and push them to GitHub.
 2. In the repository, click **Releases** → **Draft a new release**.
-3. In **Tag version**, enter a new tag like `0.6.6` (use `MAJOR.MINOR.PATCH`).
+3. In **Tag version**, enter a new tag like `0.6.7` (use `MAJOR.MINOR.PATCH`).
 4. Choose **Create new tag on publish**, leaving the target branch as `main`.
 5. Add a title and notes, then click **Publish release**. GitHub Actions will build ZIPs for the theme and each plugin and attach them to the release.
 6. After the workflow completes, download the ZIPs from the release page and upload them to WordPress to update.
 
-> To tag from the command line instead, run `git tag 0.6.6 && git push origin 0.6.6` before drafting the release.
+> To tag from the command line instead, run `git tag 0.6.7 && git push origin 0.6.7` before drafting the release.
 
 ---
 © 2025 Unge Vil. MIT License.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,10 +1,10 @@
 # Updating from GitHub releases
 
-*Latest release: 0.6.6 – Version bump for release.*
+*Latest release: 0.6.7 – Version bump for release.*
 
 ## 1. Get the new ZIPs
 1. Visit the repository's [Releases](https://github.com/ungevil/Unge-Vil-Website/releases) page.
-2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `0.6.6`).
+2. Download the newest `uv-kadence-child` theme ZIP and plugin ZIPs (`uv-core`, `uv-people`, `uv-events-bridge`) for the latest version (e.g. `0.6.7`).
 
 ## 2. Back up the site
 1. In your hosting panel or backup plugin (e.g. UpdraftPlus), run a full backup.
@@ -23,6 +23,6 @@
 3. Click **Install Now**, choose **Replace current version** when asked, then **Activate**.
 
 ## 4. Verify versions
-1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.6.6`).
+1. In **Plugins**, confirm each plugin lists the new version number (e.g. `0.6.7`).
 2. In **Appearance → Themes**, open the child theme details and verify its version.
 3. Browse a few pages on the front‑end to confirm the site loads as expected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uv-wordpress",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "test": "echo \"No JS tests configured\" && exit 0",

--- a/plugins/uv-core/blocks/activities/index.asset.php
+++ b/plugins/uv-core/blocks/activities/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.5');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.6');

--- a/plugins/uv-core/blocks/experiences/index.asset.php
+++ b/plugins/uv-core/blocks/experiences/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.5');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.6');

--- a/plugins/uv-core/blocks/locations-grid/index.asset.php
+++ b/plugins/uv-core/blocks/locations-grid/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.5');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.6');

--- a/plugins/uv-core/blocks/news/index.asset.php
+++ b/plugins/uv-core/blocks/news/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.5');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.6');

--- a/plugins/uv-core/blocks/partners/index.asset.php
+++ b/plugins/uv-core/blocks/partners/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.5');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.6');

--- a/plugins/uv-core/languages/uv-core.pot
+++ b/plugins/uv-core/languages/uv-core.pot
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-core 0.6.6\n"
+"Project-Id-Version: uv-core 0.6.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-29 19:58+0000\n"
 "PO-Revision-Date: 2025-08-29 19:58+0000\n"

--- a/plugins/uv-core/readme.md
+++ b/plugins/uv-core/readme.md
@@ -34,6 +34,8 @@ UV Core registers CPTs, taxonomies, and shortcodes.
 All strings use the `uv-core` text domain. Add `.po/.mo` files in a `languages/` folder or use a translation plugin like Polylang.
 
 ## Changelog
+### 0.6.7
+- Version bump for release.
 ### 0.6.6
 - Version bump for release.
 ### 0.6.5

--- a/plugins/uv-core/uv-core.php
+++ b/plugins/uv-core/uv-core.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Core
  * Description: CPTs, taxonomies, term images, and lightweight shortcodes.
- * Version: 0.6.6
+ * Version: 0.6.7
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil
@@ -39,7 +39,7 @@ if (!$uv_core_php_ok || !$uv_core_wp_ok) {
 }
 
 if (!defined('UV_CORE_VERSION')) {
-    define('UV_CORE_VERSION', '0.6.6');
+    define('UV_CORE_VERSION', '0.6.7');
 }
 
 $update_checker_path = dirname(__DIR__, 2) . '/plugin-update-checker/plugin-update-checker.php';

--- a/plugins/uv-events-bridge/languages/uv-events-bridge.pot
+++ b/plugins/uv-events-bridge/languages/uv-events-bridge.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-events-bridge 0.6.6\n"
+"Project-Id-Version: uv-events-bridge 0.6.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-25 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/plugins/uv-events-bridge/readme.md
+++ b/plugins/uv-events-bridge/readme.md
@@ -23,6 +23,8 @@ UV Events Bridge connects Locations to The Events Calendar.
 All strings use the `uv-events-bridge` text domain. Translation files can be placed in `languages/` or handled by translation plugins.
 
 ## Changelog
+### 0.6.7
+- Version bump for release; no functional changes.
 ### 0.6.6
 - Version bump for release; no functional changes.
 ### 0.6.5

--- a/plugins/uv-events-bridge/uv-events-bridge.php
+++ b/plugins/uv-events-bridge/uv-events-bridge.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV Events Bridge
  * Description: Adds uv_location taxonomy to The Events Calendar events and provides an upcoming events shortcode.
- * Version: 0.6.6
+ * Version: 0.6.7
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil

--- a/plugins/uv-people/languages/uv-people.pot
+++ b/plugins/uv-people/languages/uv-people.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-people 0.6.8\n"
+"Project-Id-Version: uv-people 0.6.9\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-29 19:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/plugins/uv-people/readme.md
+++ b/plugins/uv-people/readme.md
@@ -40,6 +40,8 @@ Team assignment lookups are cached in transients for faster rendering. Cache ent
 All strings use the `uv-people` text domain. Place translation files in `languages/` or manage translations through Polylang or another translation plugin.
 
 ## Changelog
+### 0.6.9
+- Version bump for release.
 ### 0.6.8
 - Version bump for release.
 ### 0.6.7

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: UV People
  * Description: Extends WordPress Users with public fields, media-library avatars, per-location assignments, and a Team grid shortcode.
- * Version: 0.6.8
+ * Version: 0.6.9
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Author: Unge Vil
@@ -13,7 +13,7 @@
 if (!defined('ABSPATH')) exit;
 
 if (!defined('UV_PEOPLE_VERSION')) {
-    define('UV_PEOPLE_VERSION', '0.6.8');
+    define('UV_PEOPLE_VERSION', '0.6.9');
 }
 
 $update_checker_path = __DIR__ . '/plugin-update-checker/plugin-update-checker.php';

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Theme Name: UV Kadence Child
-Version: 0.6.6
+Version: 0.6.7
 */
 $update_checker_path = dirname(__DIR__, 2) . '/plugin-update-checker/plugin-update-checker.php';
 if (file_exists($update_checker_path)) {

--- a/themes/uv-kadence-child/languages/uv-kadence-child.pot
+++ b/themes/uv-kadence-child/languages/uv-kadence-child.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: uv-kadence-child 0.6.6\n"
+"Project-Id-Version: uv-kadence-child 0.6.7\n"
 "Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/themes/uv-kadence-child/readme.md
+++ b/themes/uv-kadence-child/readme.md
@@ -1,6 +1,8 @@
 Kadence child theme for Unge Vil.
 
 ## Changelog
+### 0.6.7
+- Version bump for release; no functional changes.
 ### 0.6.6
 - Version bump for release; no functional changes.
 ### 0.6.5

--- a/themes/uv-kadence-child/style.css
+++ b/themes/uv-kadence-child/style.css
@@ -4,7 +4,7 @@
  Text Domain: uv-kadence-child
  Author: Unge Vil
  Author URI: https://www.ungevil.no/
-  Version: 0.6.6
+  Version: 0.6.7
  Update URI: https://github.com/Unge-Vil/Unge-Vil-Website/themes/uv-kadence-child
 */
 


### PR DESCRIPTION
## Summary
- bump versions across plugins, theme, and docs for new release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4322048bc83289f03bcdbebe72596