### PR TITLE
Add wrapper class for control panel sections

### DIFF
--- a/themes/uv-kadence-child/assets/css/control-panel.css
+++ b/themes/uv-kadence-child/assets/css/control-panel.css
@@ -54,6 +54,15 @@ body.toplevel_page_uv-control-panel h3 {
   margin-bottom: 2rem;
 }
 
+/* Wrapper for each control panel section */
+.uv-control-section {
+  margin-bottom: 2rem;
+}
+
+.uv-control-section h2 {
+  margin: 0 0 1rem;
+}
+
 .uv-avatar img {
   width: var(--uv-avatar-size);
   height: var(--uv-avatar-size);

--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -361,6 +361,7 @@ function uv_render_control_panel() {
 
     echo '<nav>';
     foreach ($sections as $section) {
+        echo '<div class="uv-control-section">';
         echo '<h2>' . esc_html($section['title']) . '</h2>';
         echo '<ul class="uv-links">';
         foreach ($section['links'] as $link) {
@@ -371,6 +372,7 @@ function uv_render_control_panel() {
             echo '</a></li>';
         }
         echo '</ul>';
+        echo '</div>';
     }
     echo '</nav>';
     echo '</div>';


### PR DESCRIPTION
## Summary
- Add `.uv-control-section` wrapper with spacing and heading styles for control panel
- Wrap each control panel section in the new class for consistent layout

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5445e4200832881b9798c3a1a7081