### PR TITLE
Refresh term data when taxonomy or query changes

### DIFF
--- a/plugins/uv-core/blocks/utils/fetchTerms.js
+++ b/plugins/uv-core/blocks/utils/fetchTerms.js
@@ -20,5 +20,5 @@ export default function fetchTerms( taxonomy, query ) {
             cache[ cacheKey ] = result;
         }
         return cache[ cacheKey ] || result;
-    }, [] );
+    }, [ taxonomy, JSON.stringify( query ) ] );
 }


### PR DESCRIPTION
## Summary
- refresh term fetching cache when taxonomy or query inputs change by passing dependencies to `useSelect`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57c9734708328bef934a3feb8b085