### PR TITLE
Add presentation attributes to control panel image

### DIFF
--- a/themes/uv-kadence-child/functions.php
+++ b/themes/uv-kadence-child/functions.php
@@ -367,7 +367,7 @@ function uv_render_control_panel() {
         foreach ($section['links'] as $link) {
             $target = $link['target'] === '_blank' ? ' target="_blank" rel="noopener"' : '';
             echo '<li><a class="uv-link-card" href="' . esc_url($link['url']) . '"' . $target . '>';
-            echo '<img src="' . esc_url($img_base . '/' . $link['img']) . '" alt="" />';
+            echo '<img src="' . esc_url($img_base . '/' . $link['img']) . '" alt="" aria-hidden="true" role="presentation" />';
             echo '<span>' . esc_html($link['label']) . '</span>';
             echo '</a></li>';
         }


### PR DESCRIPTION
## Summary
- ensure control panel image is ignored by assistive tech by adding `aria-hidden` and `role="presentation"`

## Testing
- `php -l themes/uv-kadence-child/functions.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58251196883288872da272d1e2487