### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uv-wordpress",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "scripts": {
     "test": "echo \"No JS tests configured\" && exit 0",

--- a/plugins/uv-core/blocks/activities/index.asset.php
+++ b/plugins/uv-core/blocks/activities/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.7');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.8');

--- a/plugins/uv-core/blocks/experiences/index.asset.php
+++ b/plugins/uv-core/blocks/experiences/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.7');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.8');

--- a/plugins/uv-core/blocks/locations-grid/index.asset.php
+++ b/plugins/uv-core/blocks/locations-grid/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.7');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.8');

--- a/plugins/uv-core/blocks/news/index.asset.php
+++ b/plugins/uv-core/blocks/news/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.7');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.8');

--- a/plugins/uv-core/blocks/partners/index.asset.php
+++ b/plugins/uv-core/blocks/partners/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.7');
+<?php return array('dependencies' => array('wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-api-fetch', 'wp-i18n', 'wp-server-side-render'), 'version' => '1.0.8');


### PR DESCRIPTION
## Summary
- bump plugin block assets and package version to 1.0.8

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b582e3ca1c8328881828908630aa8d