### PR TITLE
Add semantic roles to theme templates

### DIFF
--- a/themes/uv-kadence-child/author-team.php
+++ b/themes/uv-kadence-child/author-team.php
@@ -6,7 +6,7 @@
 
 get_header();
 ?>
-<main id="main-content" class="site-main">
+<main id="main-content" role="main" class="site-main">
 <?php
 $user = get_queried_object();
 if ($user instanceof WP_User) :

--- a/themes/uv-kadence-child/footer.php
+++ b/themes/uv-kadence-child/footer.php
@@ -1,0 +1,6 @@
+<footer role="contentinfo">
+    <?php // Add footer widgets or content here if needed. ?>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/themes/uv-kadence-child/header.php
+++ b/themes/uv-kadence-child/header.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header role="banner">
+    <div class="site-branding">
+        <a href="<?php echo esc_url( home_url('/') ); ?>">
+            <?php bloginfo('name'); ?>
+        </a>
+    </div>
+    <?php if ( has_nav_menu( 'primary' ) ) : ?>
+    <nav role="navigation">
+        <?php
+        wp_nav_menu( [
+            'theme_location' => 'primary',
+            'menu_id'        => 'primary-menu',
+            'container'      => false,
+        ] );
+        ?>
+    </nav>
+    <?php endif; ?>
+</header>

--- a/themes/uv-kadence-child/single-uv_experience.php
+++ b/themes/uv-kadence-child/single-uv_experience.php
@@ -10,7 +10,7 @@ do_action( 'kadence_before_main_content' );
 
 <div class="container">
     <div id="primary" class="content-area">
-        <main id="main-content" class="site-main" role="main">
+        <main id="main-content" role="main" class="site-main">
             <?php
             do_action( 'kadence_before_content' );
 

--- a/themes/uv-kadence-child/taxonomy-uv_location.php
+++ b/themes/uv-kadence-child/taxonomy-uv_location.php
@@ -13,7 +13,7 @@ if ( $term && ! is_wp_error( $term ) ) {
     $slug   = $term->slug;
     $img_id = get_term_meta( $term->term_id, 'uv_location_image', true );
     ?>
-    <main id="main-content" class="site-main">
+    <main id="main-content" role="main" class="site-main">
         <article class="uv-location">
             <div class="uv-card">
                 <?php if ( $img_id ) : ?>


### PR DESCRIPTION
## Summary
- Ensure author, taxonomy, and experience templates use `<main id="main-content" role="main">`
- Introduce header and footer templates with semantic roles and wrapped navigation
- Verified skip link points to `#main-content`

## Testing
- `php -l themes/uv-kadence-child/author-team.php`
- `php -l themes/uv-kadence-child/taxonomy-uv_location.php`
- `php -l themes/uv-kadence-child/single-uv_experience.php`
- `php -l themes/uv-kadence-child/header.php`
- `php -l themes/uv-kadence-child/footer.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b594c985cc8328a23ad97aa603b6dc