### PR TITLE
Use high-contrast colors for age pill

### DIFF
--- a/plugins/uv-people/blocks/team-grid/style.css
+++ b/plugins/uv-people/blocks/team-grid/style.css
@@ -78,8 +78,8 @@
 
 .uv-age-pill {
     display: inline-block;
-    background: var(--uv-pink, #ad1457);
-    color: #fff;
+    background: #ff30cc;
+    color: #000;
     border-radius: 999px;
     padding: .25rem .5rem;
     margin: .25rem .25rem 0 0;

--- a/themes/uv-kadence-child/assets/css/control-panel.css
+++ b/themes/uv-kadence-child/assets/css/control-panel.css
@@ -81,8 +81,8 @@ body.toplevel_page_uv-control-panel h3 {
 }
 .uv-age-pill {
   display: inline-block;
-  background: var(--uv-pink);
-  color: #fff;
+  background: #ff30cc;
+  color: #000;
   border-radius: 999px;
   padding: .25rem .5rem;
   margin: .25rem .25rem 0 0;

--- a/themes/uv-kadence-child/assets/css/theme.css
+++ b/themes/uv-kadence-child/assets/css/theme.css
@@ -35,7 +35,7 @@
 .uv-header-block{display:flex;flex-direction:column;align-items:center}
 .uv-position{font-size:1rem;color:#555}
 .uv-location-pill{display:inline-block;background:var(--uv-purple);color:#fff;border-radius:999px;padding:.25rem .5rem;margin:.25rem .25rem 0 0;font-size:.875rem}
-.uv-age-pill{display:inline-block;background:var(--uv-pink);color:#fff;border-radius:999px;padding:.25rem .5rem;margin:.25rem .25rem 0 0;font-size:.875rem}
+.uv-age-pill{display:inline-block;background:#ff30cc;color:#000;border-radius:999px;padding:.25rem .5rem;margin:.25rem .25rem 0 0;font-size:.875rem}
 .uv-articles{list-style:none;margin:0;padding:0;display:grid;gap:.5rem}
 body{font-family:'Poppins',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222}
 .uv-partner img{display:block;width:100%;height:auto;object-fit:contain}


### PR DESCRIPTION
## Summary
- style: update `.uv-age-pill` colors to black text on bright pink background for better contrast in theme and control panel
- style: apply same high-contrast colors in team grid block

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7f677288328b70d9d8a0bfa9cea