### PR TITLE
Add email visibility toggle for all team grid block

### DIFF
--- a/plugins/uv-people/blocks/all-team-grid/block.json
+++ b/plugins/uv-people/blocks/all-team-grid/block.json
@@ -33,6 +33,10 @@
       "type": "boolean",
       "default": false
     },
+    "showEmail": {
+      "type": "boolean",
+      "default": false
+    },
     "sortBy": {
       "type": "string",
       "enum": ["default", "age", "name"],

--- a/plugins/uv-people/blocks/all-team-grid/index.js
+++ b/plugins/uv-people/blocks/all-team-grid/index.js
@@ -39,6 +39,7 @@
                     allLocations,
                     showQuote,
                     showBio,
+                    showEmail,
                     showAge,
                     sortBy,
                 },
@@ -93,6 +94,12 @@
                             label: __( 'Vis bio', 'uv-people' ),
                             checked: showBio,
                             onChange: ( value ) => setAttributes( { showBio: value } ),
+                            style: { height: '40px', marginBottom: 0 },
+                        } ),
+                        el( ToggleControl, {
+                            label: __( 'Vis e-post', 'uv-people' ),
+                            checked: showEmail,
+                            onChange: ( value ) => setAttributes( { showEmail: value } ),
                             style: { height: '40px', marginBottom: 0 },
                         } ),
                         el( SelectControl, {

--- a/plugins/uv-people/languages/uv-people-nb_NO-673e52240c9697e8bc0b7830945e274b.json
+++ b/plugins/uv-people/languages/uv-people-nb_NO-673e52240c9697e8bc0b7830945e274b.json
@@ -13,6 +13,7 @@
       "Failed to load locations.": ["Kunne ikke laste lokasjoner."],
       "Locations": ["Lokasjoner"],
       "All locations": ["Alle lokasjoner"],
+      "Show email": ["Vis e-post"],
       "Columns": ["Kolonner"],
       "Loading preview…": ["Laster forhåndsvisning…"],
       "No team members found.": ["Ingen teammedlemmer funnet."]

--- a/plugins/uv-people/uv-people.php
+++ b/plugins/uv-people/uv-people.php
@@ -781,6 +781,7 @@ function uv_people_all_team_grid($atts){
         'show_nav'     => false,
         'showQuote'    => true,
         'showBio'      => false,
+        'showEmail'    => false,
         'showAge'      => false,
         'sortBy'       => 'default',
         'sort_by'      => 'default',
@@ -1020,11 +1021,11 @@ function uv_people_all_team_grid($atts){
             if($bio) echo '<div class="uv-bio">'.wp_kses_post(wpautop($bio)).'</div>';
         }
         $show_phone = get_user_meta($uid,'uv_show_phone',true)==='1';
-        if(($phone && $show_phone) || $email){
+        if(($phone && $show_phone) || ($a['showEmail'] && $email)){
             $email_label = ($lang==='en') ? __('Email:','uv-people') : __('E-post:','uv-people');
             $phone_label = ($lang==='en') ? __('Mobile:','uv-people') : __('Mobil:','uv-people');
             echo '<div class="uv-contact">';
-            if($email) echo '<div class="uv-email"><span class="label">'.esc_html($email_label).'</span><a href="mailto:'.esc_attr($email).'">'.esc_html($email).'</a></div>';
+            if($a['showEmail'] && $email) echo '<div class="uv-email"><span class="label">'.esc_html($email_label).'</span><a href="mailto:'.esc_attr($email).'">'.esc_html($email).'</a></div>';
             if($phone && $show_phone) echo '<div class="uv-mobile"><span class="label">'.esc_html($phone_label).'</span><a href="tel:'.esc_attr($phone).'">'.esc_html($phone).'</a></div>';
             echo '</div>';
         }
@@ -1111,6 +1112,10 @@ add_action('init', function(){
                 'default' => true,
             ],
             'showBio' => [
+                'type'    => 'boolean',
+                'default' => false,
+            ],
+            'showEmail' => [
                 'type'    => 'boolean',
                 'default' => false,
             ],


### PR DESCRIPTION
## Summary
- add optional `showEmail` setting to all team grid block
- render email only when enabled while still showing public mobile numbers
- translate new block toggle

## Testing
- `php -l plugins/uv-people/uv-people.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e1fcb4188328ba54e4e1af45beb4