### PR TITLE
Add uv-core-min plugin and migration docs for legacy replacement

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -1,0 +1,181 @@
+# Unge Vil inventory (legacy plugins + child theme dependencies)
+
+## Scope scanned
+- `plugins/uv-core`
+- `plugins/uv-people`
+- `themes/uv-kadence-child` (especially `functions.php`, templates, and `uv-team-manager.php`)
+
+## CPTs
+
+### `uv_activity` (from `plugins/uv-core/includes/cpt-taxonomies.php`)
+- `public: true`
+- `show_in_rest: true`
+- `has_archive: true`
+- `menu_icon: dashicons-forms`
+- `supports: [title, editor, thumbnail, excerpt]`
+- `taxonomies: [uv_location, uv_activity_type]`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+### `uv_partner`
+- `public: true`
+- `show_in_rest: true`
+- `has_archive: true`
+- `menu_icon: dashicons-heart`
+- `supports: [title, thumbnail, excerpt]`
+- `taxonomies: [uv_location, uv_partner_type]`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+### `uv_experience`
+- `public: true`
+- `show_in_rest: true`
+- `has_archive: true`
+- `menu_icon: dashicons-awards`
+- `supports: [title, editor, thumbnail, excerpt, custom-fields]`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+## Taxonomies
+
+### `uv_location`
+- object types: `[post, uv_activity, uv_partner]`
+- `public: true`
+- `hierarchical: true`
+- `show_in_rest: true`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+### `uv_activity_type`
+- object types: `[uv_activity]`
+- `public: true`
+- `hierarchical: true`
+- `show_in_rest: true`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+### `uv_partner_type`
+- object types: `[uv_partner]`
+- `public: true`
+- `hierarchical: true`
+- `show_in_rest: true`
+- rewrite behavior: **default WP rewrite** (no explicit rewrite args set)
+
+### `uv_position` (from `uv-people`)
+- object types: `null` (used as user-position dictionary)
+- `public: false`
+- `show_ui: true`
+- `hierarchical: false`
+- `show_in_rest: true`
+- `meta_box_cb: false`
+- `show_in_menu: uv-control-panel`
+- capabilities:
+  - `manage_terms/edit_terms/delete_terms: manage_categories`
+  - `assign_terms: edit_posts`
+- rewrite behavior: effectively non-frontend/admin taxonomy use
+
+## Shortcodes and frontend hooks (remove later)
+
+### Shortcodes
+- `uv-core`
+  - `[uv_locations_grid]`
+  - `[uv_news]`
+  - `[uv_activities]`
+  - `[uv_experiences]`
+  - `[uv_partners]`
+- `uv-people`
+  - `[uv_edit_profile]`
+  - `[uv_team]`
+
+### Frontend hooks / render callbacks
+- `uv-core`
+  - `template_redirect` tax redirect for `uv_location` term pages via `uv_location_page`
+  - dynamic block render callbacks for locations/news/experiences/activities/partners
+- `uv-people`
+  - dynamic block render callbacks for team grids
+  - `redirect_canonical` filter keeps `?team=` query arg
+- Child theme direct shortcode usage:
+  - `taxonomy-uv_location.php`: uses `[uv_team]`, `[uv_news]`, `[uv_activities]`
+  - `functions.php`: edit-profile admin page uses `[uv_edit_profile]`
+
+## Admin pages/menus and required capabilities
+
+### Plugin-admin pages
+- `uv-people` → Tools page `uv-people-clear-cache` (`add_management_page`)
+  - capability: `manage_options`
+  - action handler: `admin_post_uv_people_clear_team_cache` + nonce `uv_people_clear_team_cache`
+
+### Theme-admin pages (strong plugin dependencies)
+- Top-level `uv-control-panel`
+  - capability: `read`
+- Hidden submenu `uv-edit-profile`
+  - capability: `read`
+- Submenu `uv-team-manager` (from `uv-team-manager.php`)
+  - parent: `uv-control-panel`
+  - capability: `edit_users`
+  - nonce: `uv_team_manager_save`
+- `UV settings` options page (`uv-settings`)
+  - capability: `manage_options`
+
+### Taxonomy admin usage that matters
+- `uv_position` managed from control panel context (`show_in_menu => uv-control-panel`)
+- `uv_location` term edit form extended by legacy plugins (image/page/member ordering)
+
+## Used post_meta keys
+- `uv_experience_org`
+- `uv_experience_dates`
+- `uv_experience_users`
+- `uv_experience_partners`
+- `uv_partner_url`
+- `uv_partner_display`
+- `uv_external_url`
+- `uv_related_post`
+
+Legacy/migration script also touches:
+- `uv_user_id`
+- `uv_location_id`
+- `uv_is_primary`
+
+## Used term_meta keys
+- `uv_location_image`
+- `uv_location_page`
+- `uv_member_order`
+- `uv_primary_team`
+- `uv_rank_weight`
+
+## Used user_meta keys
+- `uv_avatar_id`
+- `uv_phone`
+- `uv_show_phone`
+- `uv_birthdate`
+- `uv_position_term`
+- `uv_position_nb` (legacy fallback still read in theme/plugin)
+- `uv_position_en` (legacy fallback still read in theme/plugin)
+- `uv_location_terms`
+- `uv_primary_locations`
+- `uv_bio_nb`
+- `uv_bio_en`
+- `uv_quote_nb`
+- `uv_quote_en`
+
+Legacy migration keys still referenced in code:
+- `uv_quote`
+- `uv_rank_number`
+
+## Used options (`get_option`/`update_option` keys)
+- `uv_knowledge_url` (theme settings page/control panel link)
+- `uv_people_birthdate_migrated` (one-time migration marker in `uv-people`)
+
+## Child-theme dependencies on plugin functions/hooks
+
+### Direct function dependencies
+- `uv_people_get_avatar()`
+  - used in `functions.php`, `author-team.php`, `template-parts/content-uv_experience.php`, `uv-team-manager.php`
+- `uv_core_get_experiences_for_user()`
+  - used in `author-team.php`
+
+### Data-structure dependencies (must stay)
+- CPTs: `uv_activity`, `uv_partner`, `uv_experience`
+- Taxonomies: `uv_location`, `uv_position`
+- Meta keys used in templates/admin screens:
+  - `uv_location_image`, `uv_experience_users`, `uv_experience_partners`, `uv_partner_url`, `uv_partner_display`
+  - user meta listed above (`uv_*` profile/team keys)
+
+### Hook/shortcode behavior dependencies
+- Theme patterns and taxonomy template currently assume legacy shortcodes exist.
+- Team author view depends on query-var behavior (`?team=1`) and avatar/profile data populated by legacy plugin logic.

--- a/docs/migration-checklist.md
+++ b/docs/migration-checklist.md
@@ -1,0 +1,61 @@
+# Migration checklist: move to `uv-core-min`
+
+## 1) Prepare
+1. Make sure `uv-core-min` exists in `plugins/` and can be activated.
+2. Keep **legacy plugins active** initially:
+   - `uv-core`
+   - `uv-people`
+3. Optional but recommended: ensure ACF is active (for field UI).
+
+## 2) Activate `uv-core-min` side-by-side
+1. Activate `UV Core Min` in wp-admin.
+2. Confirm admin notices:
+   - Info notice about legacy plugins still active (expected during migration)
+   - Warning notice if ACF is missing (non-fatal)
+
+## 3) Validate data/admin structures (while legacy still active)
+Test these screens/URLs:
+- `wp-admin/edit.php?post_type=uv_activity`
+- `wp-admin/edit.php?post_type=uv_partner`
+- `wp-admin/edit.php?post_type=uv_experience`
+- `wp-admin/edit-tags.php?taxonomy=uv_location`
+- `wp-admin/edit-tags.php?taxonomy=uv_activity_type&post_type=uv_activity`
+- `wp-admin/edit-tags.php?taxonomy=uv_partner_type&post_type=uv_partner`
+- `wp-admin/edit-tags.php?taxonomy=uv_position`
+
+Check that:
+- Existing content appears for all UV CPTs
+- Taxonomy terms are present
+- `uv_location` term meta (`uv_location_image`, `uv_location_page`) can be edited/saved
+- `uv_position` rank weight (`uv_rank_weight`) can be edited/saved
+
+## 4) Theme dependency review before disabling legacy plugins
+From `docs/inventory.md`, identify items still provided only by legacy plugin frontend logic:
+- shortcodes (`[uv_team]`, `[uv_news]`, `[uv_activities]`, `[uv_edit_profile]`, etc.)
+- helper functions (`uv_people_get_avatar`, `uv_core_get_experiences_for_user`)
+
+Do **not** disable legacy plugins in production until theme/templates are updated to stop relying on those frontend pieces.
+
+## 5) Staged disable test (staging environment)
+1. Deactivate `uv-core` first.
+2. Re-test all admin URLs above.
+3. Deactivate `uv-people`.
+4. Re-test admin URLs again plus any custom admin workflows (team manager/profile screens).
+
+If frontend pages break, this is expected until theme/frontend replacements are completed.
+
+## 6) Permalink/rewrite recovery steps
+If CPT/taxonomy URLs 404 after activation/deactivation:
+1. Go to `Settings → Permalinks`.
+2. Click **Save Changes** once (no value changes needed).
+3. Re-test:
+   - one `uv_activity` single
+   - one `uv_partner` single
+   - one `uv_experience` single
+   - one `uv_location` term archive URL
+
+## 7) Rollback plan
+If anything critical fails:
+1. Re-activate legacy plugins.
+2. Keep `uv-core-min` active (safe side-by-side mode).
+3. Fix remaining theme/frontend dependencies, then retry staged disable.

--- a/plugins/uv-core-min/src/Admin/Notices.php
+++ b/plugins/uv-core-min/src/Admin/Notices.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin\Admin;
+
+final class Notices
+{
+    public static function render(): void
+    {
+        if (!current_user_can('activate_plugins')) {
+            return;
+        }
+
+        self::renderLegacyActiveNotice();
+        self::renderAcfNotice();
+    }
+
+    private static function renderLegacyActiveNotice(): void
+    {
+        include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        $legacy = [];
+        if (is_plugin_active('uv-core/uv-core.php')) {
+            $legacy[] = 'UV Core';
+        }
+        if (is_plugin_active('uv-people/uv-people.php')) {
+            $legacy[] = 'UV People';
+        }
+
+        if ($legacy === []) {
+            return;
+        }
+
+        echo '<div class="notice notice-info"><p>';
+        printf(
+            esc_html__('UV Core Min is active while legacy plugin(s) are still active: %s. This is supported during migration.', 'uv-core-min'),
+            esc_html(implode(', ', $legacy))
+        );
+        echo '</p></div>';
+    }
+
+    private static function renderAcfNotice(): void
+    {
+        if (function_exists('acf_get_field_groups')) {
+            return;
+        }
+
+        echo '<div class="notice notice-warning"><p>';
+        echo esc_html__('UV Core Min recommends Advanced Custom Fields (ACF) for field UI management. Core data structures still work without ACF.', 'uv-core-min');
+        echo '</p></div>';
+    }
+}

--- a/plugins/uv-core-min/src/Admin/TermFields.php
+++ b/plugins/uv-core-min/src/Admin/TermFields.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin\Admin;
+
+final class TermFields
+{
+    public static function register(): void
+    {
+        add_action('uv_location_add_form_fields', [self::class, 'renderLocationAddFields']);
+        add_action('uv_location_edit_form_fields', [self::class, 'renderLocationEditFields']);
+        add_action('created_uv_location', [self::class, 'saveLocation']);
+        add_action('edited_uv_location', [self::class, 'saveLocation']);
+
+        add_action('uv_position_add_form_fields', [self::class, 'renderPositionAddFields']);
+        add_action('uv_position_edit_form_fields', [self::class, 'renderPositionEditFields']);
+        add_action('created_uv_position', [self::class, 'savePosition']);
+        add_action('edited_uv_position', [self::class, 'savePosition']);
+    }
+
+    public static function renderLocationAddFields(): void
+    {
+        wp_nonce_field('uv_core_min_location_term_meta', 'uv_core_min_location_nonce');
+        ?>
+        <div class="form-field">
+            <label for="uv_location_image"><?php esc_html_e('Stedsbilde (attachment ID)', 'uv-core-min'); ?></label>
+            <input type="number" id="uv_location_image" name="uv_location_image" value="" min="0">
+        </div>
+        <div class="form-field">
+            <label for="uv_location_page"><?php esc_html_e('Stedside', 'uv-core-min'); ?></label>
+            <?php wp_dropdown_pages([
+                'post_type' => 'page',
+                'name' => 'uv_location_page',
+                'id' => 'uv_location_page',
+                'show_option_none' => esc_html__('— Ingen —', 'uv-core-min'),
+            ]); ?>
+        </div>
+        <?php
+    }
+
+    public static function renderLocationEditFields(\WP_Term $term): void
+    {
+        $imageId = absint((string) get_term_meta($term->term_id, 'uv_location_image', true));
+        $pageId = absint((string) get_term_meta($term->term_id, 'uv_location_page', true));
+        wp_nonce_field('uv_core_min_location_term_meta', 'uv_core_min_location_nonce');
+        ?>
+        <tr class="form-field">
+            <th scope="row"><label for="uv_location_image"><?php esc_html_e('Stedsbilde (attachment ID)', 'uv-core-min'); ?></label></th>
+            <td><input type="number" id="uv_location_image" name="uv_location_image" value="<?php echo esc_attr((string) $imageId); ?>" min="0"></td>
+        </tr>
+        <tr class="form-field">
+            <th scope="row"><label for="uv_location_page"><?php esc_html_e('Stedside', 'uv-core-min'); ?></label></th>
+            <td>
+                <?php wp_dropdown_pages([
+                    'post_type' => 'page',
+                    'name' => 'uv_location_page',
+                    'id' => 'uv_location_page',
+                    'selected' => $pageId,
+                    'show_option_none' => esc_html__('— Ingen —', 'uv-core-min'),
+                ]); ?>
+            </td>
+        </tr>
+        <?php
+    }
+
+    public static function saveLocation(int $termId): void
+    {
+        if (!current_user_can('manage_categories')) {
+            return;
+        }
+        if (!isset($_POST['uv_core_min_location_nonce']) || !wp_verify_nonce(sanitize_text_field((string) wp_unslash($_POST['uv_core_min_location_nonce'])), 'uv_core_min_location_term_meta')) {
+            return;
+        }
+
+        if (isset($_POST['uv_location_image'])) {
+            update_term_meta($termId, 'uv_location_image', absint((string) wp_unslash($_POST['uv_location_image'])));
+        }
+
+        if (isset($_POST['uv_location_page'])) {
+            update_term_meta($termId, 'uv_location_page', absint((string) wp_unslash($_POST['uv_location_page'])));
+        }
+    }
+
+    public static function renderPositionAddFields(): void
+    {
+        wp_nonce_field('uv_core_min_position_term_meta', 'uv_core_min_position_nonce');
+        ?>
+        <div class="form-field term-rank-weight-wrap">
+            <label for="uv_rank_weight"><?php esc_html_e('Rangeringsvekt', 'uv-core-min'); ?></label>
+            <input type="number" name="uv_rank_weight" id="uv_rank_weight" value="0" step="1" min="0">
+        </div>
+        <?php
+    }
+
+    public static function renderPositionEditFields(\WP_Term $term): void
+    {
+        $value = (int) get_term_meta($term->term_id, 'uv_rank_weight', true);
+        wp_nonce_field('uv_core_min_position_term_meta', 'uv_core_min_position_nonce');
+        ?>
+        <tr class="form-field term-rank-weight-wrap">
+            <th scope="row"><label for="uv_rank_weight"><?php esc_html_e('Rangeringsvekt', 'uv-core-min'); ?></label></th>
+            <td><input type="number" name="uv_rank_weight" id="uv_rank_weight" value="<?php echo esc_attr((string) $value); ?>" step="1" min="0"></td>
+        </tr>
+        <?php
+    }
+
+    public static function savePosition(int $termId): void
+    {
+        if (!current_user_can('manage_categories')) {
+            return;
+        }
+        if (!isset($_POST['uv_core_min_position_nonce']) || !wp_verify_nonce(sanitize_text_field((string) wp_unslash($_POST['uv_core_min_position_nonce'])), 'uv_core_min_position_term_meta')) {
+            return;
+        }
+        if (!isset($_POST['uv_rank_weight'])) {
+            return;
+        }
+
+        update_term_meta($termId, 'uv_rank_weight', (int) wp_unslash($_POST['uv_rank_weight']));
+    }
+}

--- a/plugins/uv-core-min/src/Meta.php
+++ b/plugins/uv-core-min/src/Meta.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin;
+
+final class Meta
+{
+    public static function register(): void
+    {
+        register_term_meta('uv_location', 'uv_location_image', [
+            'type' => 'integer',
+            'single' => true,
+            'sanitize_callback' => 'absint',
+            'show_in_rest' => true,
+        ]);
+
+        register_term_meta('uv_location', 'uv_location_page', [
+            'type' => 'integer',
+            'single' => true,
+            'sanitize_callback' => 'absint',
+            'show_in_rest' => true,
+        ]);
+
+        register_term_meta('uv_location', 'uv_member_order', [
+            'type' => 'array',
+            'single' => true,
+            'show_in_rest' => true,
+            'auth_callback' => static fn (): bool => current_user_can('manage_categories'),
+        ]);
+
+        register_term_meta('uv_location', 'uv_primary_team', [
+            'type' => 'array',
+            'single' => true,
+            'show_in_rest' => true,
+            'auth_callback' => static fn (): bool => current_user_can('manage_categories'),
+        ]);
+
+        register_term_meta('uv_position', 'uv_rank_weight', [
+            'type' => 'number',
+            'single' => true,
+            'sanitize_callback' => 'intval',
+            'show_in_rest' => true,
+        ]);
+
+        self::registerPostMeta('uv_partner', 'uv_partner_url', 'string', 'esc_url_raw');
+        self::registerPostMeta('uv_partner', 'uv_partner_display', 'string', [self::class, 'sanitizePartnerDisplay']);
+        self::registerPostMeta('uv_activity', 'uv_external_url', 'string', 'esc_url_raw');
+        self::registerPostMeta('post', 'uv_related_post', 'integer', 'absint');
+        self::registerPostMeta('uv_experience', 'uv_experience_org', 'string', 'sanitize_text_field');
+        self::registerPostMeta('uv_experience', 'uv_experience_dates', 'string', 'sanitize_text_field');
+        self::registerPostMeta('uv_experience', 'uv_experience_users', 'integer', 'absint', false);
+        self::registerPostMeta('uv_experience', 'uv_experience_partners', 'integer', 'absint', false);
+    }
+
+    private static function registerPostMeta(
+        string $postType,
+        string $key,
+        string $type,
+        $sanitizeCallback,
+        bool $single = true
+    ): void {
+        register_post_meta($postType, $key, [
+            'single' => $single,
+            'type' => $type,
+            'sanitize_callback' => $sanitizeCallback,
+            'show_in_rest' => true,
+            'auth_callback' => static fn (): bool => current_user_can('edit_posts'),
+        ]);
+    }
+
+    public static function sanitizePartnerDisplay($value): string
+    {
+        $allowed = ['logo_title', 'logo_only', 'circle_title', 'title_only'];
+        $value = sanitize_key((string) $value);
+
+        return in_array($value, $allowed, true) ? $value : 'logo_title';
+    }
+}

--- a/plugins/uv-core-min/src/Plugin.php
+++ b/plugins/uv-core-min/src/Plugin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin;
+
+use UV\CoreMin\Admin\Notices;
+use UV\CoreMin\Admin\TermFields;
+
+final class Plugin
+{
+    private static string $pluginFile;
+
+    public static function boot(string $pluginFile): void
+    {
+        self::$pluginFile = $pluginFile;
+
+        register_activation_hook(self::$pluginFile, [self::class, 'activate']);
+        register_deactivation_hook(self::$pluginFile, [self::class, 'deactivate']);
+
+        add_action('init', [PostTypes::class, 'register']);
+        add_action('init', [Taxonomies::class, 'register']);
+        add_action('init', [Meta::class, 'register']);
+        add_action('admin_notices', [Notices::class, 'render']);
+
+        TermFields::register();
+    }
+
+    public static function activate(): void
+    {
+        Taxonomies::register();
+        PostTypes::register();
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate(): void
+    {
+        flush_rewrite_rules();
+    }
+}

--- a/plugins/uv-core-min/src/PostTypes.php
+++ b/plugins/uv-core-min/src/PostTypes.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin;
+
+final class PostTypes
+{
+    public static function register(): void
+    {
+        register_post_type('uv_activity', [
+            'label' => esc_html__('Aktiviteter', 'uv-core-min'),
+            'public' => true,
+            'show_in_rest' => true,
+            'has_archive' => true,
+            'menu_icon' => 'dashicons-forms',
+            'supports' => ['title', 'editor', 'thumbnail', 'excerpt'],
+            'taxonomies' => ['uv_location', 'uv_activity_type'],
+        ]);
+
+        register_post_type('uv_partner', [
+            'label' => esc_html__('Partnere', 'uv-core-min'),
+            'public' => true,
+            'show_in_rest' => true,
+            'has_archive' => true,
+            'menu_icon' => 'dashicons-heart',
+            'supports' => ['title', 'thumbnail', 'excerpt'],
+            'taxonomies' => ['uv_location', 'uv_partner_type'],
+        ]);
+
+        register_post_type('uv_experience', [
+            'label' => esc_html__('Erfaringer', 'uv-core-min'),
+            'public' => true,
+            'show_in_rest' => true,
+            'has_archive' => true,
+            'menu_icon' => 'dashicons-awards',
+            'supports' => ['title', 'editor', 'thumbnail', 'excerpt', 'custom-fields'],
+        ]);
+    }
+}

--- a/plugins/uv-core-min/src/Taxonomies.php
+++ b/plugins/uv-core-min/src/Taxonomies.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UV\CoreMin;
+
+final class Taxonomies
+{
+    public static function register(): void
+    {
+        register_taxonomy('uv_location', ['post', 'uv_activity', 'uv_partner'], [
+            'label' => esc_html__('Steder', 'uv-core-min'),
+            'public' => true,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+        ]);
+
+        register_taxonomy('uv_activity_type', ['uv_activity'], [
+            'label' => esc_html__('Aktivitetstyper', 'uv-core-min'),
+            'public' => true,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+        ]);
+
+        register_taxonomy('uv_partner_type', ['uv_partner'], [
+            'label' => esc_html__('Partnertyper', 'uv-core-min'),
+            'public' => true,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+        ]);
+
+        register_taxonomy('uv_position', null, [
+            'label' => esc_html__('Stillinger', 'uv-core-min'),
+            'public' => false,
+            'show_ui' => true,
+            'hierarchical' => false,
+            'show_in_rest' => true,
+            'meta_box_cb' => false,
+            'show_in_menu' => 'uv-control-panel',
+            'capabilities' => [
+                'manage_terms' => 'manage_categories',
+                'edit_terms' => 'manage_categories',
+                'delete_terms' => 'manage_categories',
+                'assign_terms' => 'edit_posts',
+            ],
+        ]);
+    }
+}

--- a/plugins/uv-core-min/uv-core-min.php
+++ b/plugins/uv-core-min/uv-core-min.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: UV Core Min
+ * Description: Minimal data/admin core for Unge Vil CPTs, taxonomies, and essential metadata.
+ * Version: 0.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Author: Unge Vil
+ * Text Domain: uv-core-min
+ */
+
+declare(strict_types=1);
+
+namespace UV\CoreMin;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/src/Plugin.php';
+require_once __DIR__ . '/src/PostTypes.php';
+require_once __DIR__ . '/src/Taxonomies.php';
+require_once __DIR__ . '/src/Meta.php';
+require_once __DIR__ . '/src/Admin/Notices.php';
+require_once __DIR__ . '/src/Admin/TermFields.php';
+
+Plugin::boot(__FILE__);


### PR DESCRIPTION
## Summary
- Added a new plugin at `plugins/uv-core-min/` designed to run side-by-side with existing Unge Vil plugins.
- Registered core UV data structures with matching slugs/behavior:
  - CPTs: `uv_activity`, `uv_partner`, `uv_experience`
  - Taxonomies: `uv_location`, `uv_activity_type`, `uv_partner_type`, `uv_position`
- Added minimal admin-focused metadata support and term admin fields for:
  - `uv_location_image`, `uv_location_page`
  - `uv_rank_weight` for `uv_position`
- Added capability + nonce checks for all custom admin save actions.
- Added activation/deactivation hooks that flush rewrite rules only on activation/deactivation.
- Added admin notices for:
  - legacy plugins still active (informational)
  - missing ACF dependency (non-fatal warning)

## Documentation
- Added `docs/inventory.md` with:
  - CPT/tax inventory and rewrite behavior
  - shortcodes/frontend hooks slated for removal
  - admin pages/capabilities
  - post/user/term meta keys and option keys
  - child-theme dependencies on plugin functions/hooks
- Added `docs/migration-checklist.md` with staged activation/testing/deactivation procedure and permalink recovery steps.

## Validation
- Ran PHP syntax checks on all new plugin files (`php -l`) successfully.

## Notes
- This plugin intentionally omits shortcode/frontend rendering logic and focuses on data/admin structures for migration-safe coexistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7e1cd9a88328bd753028919c15ce)